### PR TITLE
ci: add in-cluster e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install k3d
         run: |
-          curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/v5.7.5/install.sh | TAG=v5.7.5 bash
           k3d version
 
       - name: Setup Terraform

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ devspace dev -w
 ### Run tests
 
 ```bash
-devspace run test:e2e
+devspace run test-e2e
 ```
 
 See [E2E Testing](https://github.com/agynio/architecture/blob/main/architecture/operations/e2e-testing.md).

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -76,6 +76,10 @@ pipelines:
             [ -f /opt/app/data/pnpm-lock.yaml ] && break
             sleep 2
           done
+          if [ ! -f /opt/app/data/pnpm-lock.yaml ]; then
+            echo "ERROR: file sync timed out — pnpm-lock.yaml not found after 120s"
+            exit 1
+          fi
           cd /opt/app/data && corepack enable && pnpm install --frozen-lockfile && pnpm test:e2e
         '
       EXIT_CODE=$?


### PR DESCRIPTION
## Summary
- add in-cluster e2e CI job using bootstrap/k3d and devspace
- upload Playwright reports/traces from the new job

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test
- E2E_BASE_URL=http://localhost:5173 pnpm test:e2e

Closes #7