### PR TITLE
fix(config): preserve api base path

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,7 @@ function deriveBase(raw: string, options: { stripApi: boolean }): string {
 
 const rawApiBase = requireEnv('VITE_API_BASE_URL');
 
-const apiBaseUrl = deriveBase(rawApiBase, { stripApi: true });
+const apiBaseUrl = deriveBase(rawApiBase, { stripApi: false });
 export const config = {
   apiBaseUrl,
 };


### PR DESCRIPTION
## Summary
- keep VITE_API_BASE_URL path intact so ConnectRPC baseUrl includes /api
- stop stripping /api in config derivation

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test

Closes #22