### PR TITLE
fix(auth): preserve return-to redirect

### DIFF
--- a/src/auth/AuthCallbackScreen.tsx
+++ b/src/auth/AuthCallbackScreen.tsx
@@ -1,18 +1,20 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/Button';
+import { getReturnToFromError, getSigninRedirectArgs, resolveReturnTo } from './return-to';
 
 export function AuthCallbackScreen() {
   const auth = useAuth();
   const navigate = useNavigate();
   const isPending = auth.isLoading || Boolean(auth.activeNavigator);
+  const returnTo = useMemo(() => resolveReturnTo(auth.user?.state), [auth.user?.state]);
 
   useEffect(() => {
     if (isPending) return;
     if (!auth.isAuthenticated) return;
-    navigate('/', { replace: true });
-  }, [auth.isAuthenticated, isPending, navigate]);
+    navigate(returnTo, { replace: true });
+  }, [auth.isAuthenticated, isPending, navigate, returnTo]);
 
   if (isPending) {
     return (
@@ -28,7 +30,13 @@ export function AuthCallbackScreen() {
         <div className="rounded-lg border bg-background px-6 py-5 text-center shadow-sm">
           <div className="text-sm font-medium text-foreground">We couldn&apos;t sign you in.</div>
           <div className="mt-1 text-xs text-muted-foreground">{auth.error.message}</div>
-          <Button className="mt-4" size="sm" onClick={() => void auth.signinRedirect()}>
+          <Button
+            className="mt-4"
+            size="sm"
+            onClick={() =>
+              void auth.signinRedirect(getSigninRedirectArgs({ returnTo: getReturnToFromError(auth.error) }))
+            }
+          >
             Try again
           </Button>
         </div>

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -121,7 +121,7 @@ function AuthErrorBoundary({ children }: { children: ReactNode }) {
 
   if (error) {
     return (
-    <SignedOutScreen
+      <SignedOutScreen
         onSignIn={() => void signinRedirect(getSigninRedirectArgs())}
         title="We couldn't sign you in."
         subtitle="Please sign in again to continue."

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from 'react-oidc-context';
 import { Button } from '@/components/Button';
 import { oidcConfig } from '@/config';
 import { clearSignedOutFlag, readSignedOutFlag } from './signed-out';
+import { getSigninRedirectArgs } from './return-to';
 import { userManager } from './user-manager';
 
 type AuthGateProps = {
@@ -63,7 +64,7 @@ function RequireAuth({ children }: { children: ReactNode }) {
   const handleSignIn = useCallback(() => {
     clearSignedOutFlag();
     setSignedOut(false);
-    void auth.signinRedirect();
+    void auth.signinRedirect(getSigninRedirectArgs());
   }, [auth]);
 
   useEffect(() => {
@@ -82,7 +83,7 @@ function RequireAuth({ children }: { children: ReactNode }) {
     if (signedOut) return;
     if (auth.isLoading || auth.activeNavigator || auth.isAuthenticated) return;
     if (hasAuthParams()) return;
-    void auth.signinRedirect();
+    void auth.signinRedirect(getSigninRedirectArgs());
   }, [auth, signedOut]);
 
   if (signedOut && !auth.isAuthenticated) {
@@ -120,8 +121,8 @@ function AuthErrorBoundary({ children }: { children: ReactNode }) {
 
   if (error) {
     return (
-      <SignedOutScreen
-        onSignIn={() => void signinRedirect()}
+    <SignedOutScreen
+        onSignIn={() => void signinRedirect(getSigninRedirectArgs())}
         title="We couldn't sign you in."
         subtitle="Please sign in again to continue."
       />

--- a/src/auth/return-to.ts
+++ b/src/auth/return-to.ts
@@ -1,0 +1,68 @@
+import type { SigninRedirectArgs } from 'oidc-client-ts';
+
+export type ReturnToLocation = Pick<Location, 'origin' | 'pathname' | 'search' | 'hash'>;
+
+const DEFAULT_RETURN_TO = '/';
+const DISALLOWED_RETURN_TO_PATHS = new Set(['/callback', '/silent-renew']);
+
+function normalizeReturnTo(value: string, origin: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (!trimmed.startsWith('/')) return null;
+  if (trimmed.startsWith('//')) return null;
+
+  let url: URL;
+  try {
+    url = new URL(trimmed, origin);
+  } catch {
+    return null;
+  }
+
+  if (url.origin !== origin) return null;
+  if (DISALLOWED_RETURN_TO_PATHS.has(url.pathname)) return null;
+
+  const normalized = `${url.pathname}${url.search}${url.hash}`;
+  return normalized.length > 0 ? normalized : null;
+}
+
+function readReturnToFromState(state: unknown, origin: string): string | null {
+  if (!state || typeof state !== 'object') return null;
+  if (!('returnTo' in state)) return null;
+  const candidate = (state as { returnTo?: unknown }).returnTo;
+  if (typeof candidate !== 'string') return null;
+  return normalizeReturnTo(candidate, origin);
+}
+
+function readReturnToFromError(error: unknown, origin: string): string | null {
+  if (!error || typeof error !== 'object') return null;
+  const directState = (error as { state?: unknown }).state;
+  const direct = readReturnToFromState(directState, origin);
+  if (direct) return direct;
+  const innerError = (error as { innerError?: unknown }).innerError;
+  if (!innerError || typeof innerError !== 'object') return null;
+  const innerState = (innerError as { state?: unknown }).state;
+  return readReturnToFromState(innerState, origin);
+}
+
+export function buildReturnTo(location: ReturnToLocation = window.location): string {
+  const candidate = `${location.pathname}${location.search}${location.hash}`;
+  return normalizeReturnTo(candidate, location.origin) ?? DEFAULT_RETURN_TO;
+}
+
+export function resolveReturnTo(state: unknown, origin: string = window.location.origin): string {
+  return readReturnToFromState(state, origin) ?? DEFAULT_RETURN_TO;
+}
+
+export function getReturnToFromError(error: unknown, origin: string = window.location.origin): string | null {
+  return readReturnToFromError(error, origin);
+}
+
+export function getSigninRedirectArgs(
+  options: { returnTo?: string | null; location?: ReturnToLocation } = {},
+): SigninRedirectArgs {
+  const location = options.location ?? window.location;
+  const origin = location.origin;
+  const override = typeof options.returnTo === 'string' ? normalizeReturnTo(options.returnTo, origin) : null;
+  const returnTo = override ?? buildReturnTo(location);
+  return { state: { returnTo } };
+}

--- a/src/auth/return-to.ts
+++ b/src/auth/return-to.ts
@@ -19,6 +19,7 @@ function normalizeReturnTo(value: string, origin: string): string | null {
   }
 
   if (url.origin !== origin) return null;
+  if (url.pathname.startsWith('//')) return null;
   if (DISALLOWED_RETURN_TO_PATHS.has(url.pathname)) return null;
 
   const normalized = `${url.pathname}${url.search}${url.hash}`;

--- a/test/unit/returnTo.spec.ts
+++ b/test/unit/returnTo.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildReturnTo,
+  getReturnToFromError,
+  getSigninRedirectArgs,
+  resolveReturnTo,
+  type ReturnToLocation,
+} from '../../src/auth/return-to';
+
+const baseLocation: ReturnToLocation = {
+  origin: 'https://app.test',
+  pathname: '/message/abc',
+  search: '?orgId=org-1',
+  hash: '#detail',
+};
+
+describe('return-to helpers', () => {
+  it('builds return-to from the current location', () => {
+    expect(buildReturnTo(baseLocation)).toBe('/message/abc?orgId=org-1#detail');
+  });
+
+  it('falls back to root for disallowed paths', () => {
+    expect(buildReturnTo({ ...baseLocation, pathname: '/callback', search: '', hash: '' })).toBe('/');
+  });
+
+  it('resolves return-to from signin state', () => {
+    expect(resolveReturnTo({ returnTo: '/runs/123?orgId=org-2' }, baseLocation.origin)).toBe('/runs/123?orgId=org-2');
+  });
+
+  it('rejects unsafe return-to values', () => {
+    expect(resolveReturnTo({ returnTo: 'https://evil.test/steal' }, baseLocation.origin)).toBe('/');
+  });
+
+  it('extracts return-to from auth errors', () => {
+    const error = { innerError: { state: { returnTo: '/message/xyz?orgId=org-9' } } };
+    expect(getReturnToFromError(error, baseLocation.origin)).toBe('/message/xyz?orgId=org-9');
+  });
+
+  it('uses overrides when building redirect args', () => {
+    const args = getSigninRedirectArgs({ returnTo: '/runs/override', location: baseLocation });
+    expect(args.state).toEqual({ returnTo: '/runs/override' });
+  });
+});

--- a/test/unit/returnTo.spec.ts
+++ b/test/unit/returnTo.spec.ts
@@ -31,6 +31,10 @@ describe('return-to helpers', () => {
     expect(resolveReturnTo({ returnTo: 'https://evil.test/steal' }, baseLocation.origin)).toBe('/');
   });
 
+  it('rejects normalized protocol-relative paths', () => {
+    expect(resolveReturnTo({ returnTo: '/.//evil.com' }, baseLocation.origin)).toBe('/');
+  });
+
   it('extracts return-to from auth errors', () => {
     const error = { innerError: { state: { returnTo: '/message/xyz?orgId=org-9' } } };
     expect(getReturnToFromError(error, baseLocation.origin)).toBe('/message/xyz?orgId=org-9');


### PR DESCRIPTION
## Summary
- add return-to validation/helpers for OIDC redirect state
- redirect from callback to the validated return-to path
- reuse signin redirect args across auth entry points with unit tests

## Testing
- pnpm lint
- pnpm test
- pnpm typecheck

Refs #28