### PR TITLE
Render unsupported tracing spans

### DIFF
--- a/src/api/hooks/runs.ts
+++ b/src/api/hooks/runs.ts
@@ -38,10 +38,10 @@ export function useRunTimelineEventTotals(
   filters: { types: string[]; statuses: string[] },
 ) {
   return useQuery({
-    enabled: !!runId,
+    enabled: !!runId && !!organizationId,
     queryKey: ['agents', 'runs', organizationId ?? '', runId, 'timeline', 'events', 'totals', filters],
     queryFn: () =>
-      runs.timelineEventTotals(runId as string, {
+      runs.timelineEventTotals(organizationId as string, runId as string, {
         types: filters.types.length > 0 ? filters.types.join(',') : undefined,
         statuses: filters.statuses.length > 0 ? filters.statuses.join(',') : undefined,
       }),

--- a/src/api/modules/runs.ts
+++ b/src/api/modules/runs.ts
@@ -19,6 +19,7 @@ import type {
   RunEventStatus,
   RunEventType,
   RunStatus,
+  RunTimelineEvent,
   RunTimelineEventsCursor,
   RunTimelineEventsResponse,
   RunTimelineSummary,
@@ -132,14 +133,27 @@ function mapCountsByStatus(countsByStatus: Record<string, bigint>): Record<RunEv
   return counts;
 }
 
-function mapEventTypesToSpanNames(types: RunEventType[]): string[] | null {
-  if (types.includes('unsupported')) return null;
+function mapEventTypesToSpanNames(types: RunEventType[]): string[] {
   const spanNames: string[] = [];
   for (const type of types) {
     const mapped = EVENT_TYPE_TO_SPAN_NAME[type];
     if (mapped) spanNames.push(mapped);
   }
   return spanNames;
+}
+
+function requiresUnsupportedSpanFetch(types: RunEventType[]): boolean {
+  return types.includes('unsupported');
+}
+
+function filterEventsByTypes(events: RunTimelineEvent[], types: RunEventType[]): RunTimelineEvent[] {
+  if (types.length === 0) return events;
+  return events.filter((event) => types.includes(event.type));
+}
+
+function countEventsByType(events: RunTimelineEvent[], types: RunEventType[]): number {
+  if (types.length === 0) return events.length;
+  return filterEventsByTypes(events, types).length;
 }
 
 function mapEventStatusesToSpanStatuses(statuses: RunEventStatus[]): SpanStatus[] {
@@ -279,7 +293,9 @@ export const runs = {
     const types = parseEventTypes(params.types);
     if (types.length > 0) {
       const spanNames = mapEventTypesToSpanNames(types);
-      if (spanNames) filter.names = spanNames;
+      if (spanNames.length > 0 && !requiresUnsupportedSpanFetch(types)) {
+        filter.names = spanNames;
+      }
     }
     const statuses = parseEventStatuses(params.statuses);
     if (statuses.length > 0) {
@@ -299,7 +315,8 @@ export const runs = {
     });
 
     const spans = flattenResourceSpans(resp.resourceSpans);
-    const items = spans.map(({ span, resourceAttrs }) => spanToEvent(span, resourceAttrs));
+    const convertedItems = spans.map(({ span, resourceAttrs }) => spanToEvent(span, resourceAttrs));
+    const items = filterEventsByTypes(convertedItems, types);
 
     return {
       items,
@@ -314,9 +331,9 @@ export const runs = {
       traceId: hexToBytes(runId),
     };
     const types = parseEventTypes(params?.types);
-    if (types.length > 0) {
-      const spanNames = mapEventTypesToSpanNames(types);
-      if (spanNames) req.names = spanNames;
+    const spanNames = mapEventTypesToSpanNames(types);
+    if (types.length > 0 && spanNames.length > 0 && !requiresUnsupportedSpanFetch(types)) {
+      req.names = spanNames;
     }
     const statuses = parseEventStatuses(params?.statuses);
     if (statuses.length > 0) {
@@ -327,7 +344,13 @@ export const runs = {
     }
 
     const resp = await tracingClient.getTraceSpanTotals(req);
-    const tokenUsage = resp.tokenUsage;
+    const includesUnsupported = requiresUnsupportedSpanFetch(types);
+    const eventCount = includesUnsupported
+      ? await runs.countTimelineEvents(req, types)
+      : Number(resp.spanCount);
+    const tokenUsage = includesUnsupported
+      ? await runs.filteredTokenUsage(req, spanNames)
+      : resp.tokenUsage;
     return {
       runId,
       filters: {
@@ -335,7 +358,7 @@ export const runs = {
         statuses: params?.statuses ? parseEventStatuses(params.statuses) : [],
       },
       totals: {
-        eventCount: Number(resp.spanCount),
+        eventCount,
         tokenUsage: {
           input: Number(tokenUsage?.inputTokens ?? 0n),
           cached: Number(tokenUsage?.cacheReadInputTokens ?? 0n),
@@ -345,6 +368,34 @@ export const runs = {
         },
       },
     };
+  },
+  filteredTokenUsage: async (
+    filter: { traceId: Uint8Array; statuses?: SpanStatus[] },
+    spanNames: string[],
+  ) => {
+    if (spanNames.length === 0) return undefined;
+    const resp = await tracingClient.getTraceSpanTotals({ ...filter, names: spanNames });
+    return resp.tokenUsage;
+  },
+  countTimelineEvents: async (
+    filter: { traceId: Uint8Array; statuses?: SpanStatus[] },
+    types: RunEventType[],
+  ): Promise<number> => {
+    let count = 0;
+    let pageToken = '';
+    do {
+      const resp = await tracingClient.listSpans({
+        filter,
+        pageSize: 250,
+        orderBy: ListSpansOrderBy.START_TIME_DESC,
+        pageToken,
+      });
+      const spans = flattenResourceSpans(resp.resourceSpans);
+      const items = spans.map(({ span, resourceAttrs }) => spanToEvent(span, resourceAttrs));
+      count += countEventsByType(items, types);
+      pageToken = resp.nextPageToken;
+    } while (pageToken);
+    return count;
   },
   toolOutputSnapshot: async (
     runId: string,

--- a/src/api/modules/runs.ts
+++ b/src/api/modules/runs.ts
@@ -200,6 +200,10 @@ function decodeCursorFromPageToken(token: string): RunTimelineEventsCursor | nul
   return { ts, id };
 }
 
+function cursorFromEvent(event: RunTimelineEvent): RunTimelineEventsCursor {
+  return { ts: event.ts, id: event.id };
+}
+
 export const runs = {
   listOrganizationRuns: async (
     organizationId: string,
@@ -304,14 +308,46 @@ export const runs = {
         filter.statuses = spanStatuses;
       }
     }
+    const limit = params.limit ?? 50;
+    const orderBy = params.order === 'asc'
+      ? ListSpansOrderBy.START_TIME_ASC
+      : ListSpansOrderBy.START_TIME_DESC;
+    const initialPageToken = buildPageToken(params.cursorTs, params.cursorId) ?? '';
+
+    if (requiresUnsupportedSpanFetch(types)) {
+      const items: RunTimelineEvent[] = [];
+      let pageToken = initialPageToken;
+      while (items.length < limit) {
+        const resp = await tracingClient.listSpans({
+          organizationId,
+          filter,
+          pageSize: limit - items.length,
+          orderBy,
+          pageToken,
+        });
+        const spans = flattenResourceSpans(resp.resourceSpans);
+        const convertedItems = spans.map(({ span, resourceAttrs }) => spanToEvent(span, resourceAttrs));
+        items.push(...filterEventsByTypes(convertedItems, types));
+        if (!resp.nextPageToken) {
+          return { items, nextCursor: null };
+        }
+        if (resp.nextPageToken === pageToken) {
+          throw new Error('Non-advancing timeline page token');
+        }
+        pageToken = resp.nextPageToken;
+      }
+      return {
+        items,
+        nextCursor: items.length > 0 ? cursorFromEvent(items[items.length - 1]) : null,
+      };
+    }
+
     const resp = await tracingClient.listSpans({
       organizationId,
       filter,
-      pageSize: params.limit ?? 50,
-      orderBy: params.order === 'asc'
-        ? ListSpansOrderBy.START_TIME_ASC
-        : ListSpansOrderBy.START_TIME_DESC,
-      pageToken: buildPageToken(params.cursorTs, params.cursorId) ?? '',
+      pageSize: limit,
+      orderBy,
+      pageToken: initialPageToken,
     });
 
     const spans = flattenResourceSpans(resp.resourceSpans);

--- a/src/api/modules/runs.ts
+++ b/src/api/modules/runs.ts
@@ -324,6 +324,7 @@ export const runs = {
     };
   },
   timelineEventTotals: async (
+    organizationId: string,
     runId: string,
     params?: { types?: string; statuses?: string },
   ): Promise<RunTimelineTotalsResponse> => {
@@ -346,7 +347,7 @@ export const runs = {
     const resp = await tracingClient.getTraceSpanTotals(req);
     const includesUnsupported = requiresUnsupportedSpanFetch(types);
     const eventCount = includesUnsupported
-      ? await runs.countTimelineEvents(req, types)
+      ? await runs.countTimelineEvents(organizationId, req, types)
       : Number(resp.spanCount);
     const tokenUsage = includesUnsupported
       ? await runs.filteredTokenUsage(req, spanNames)
@@ -378,6 +379,7 @@ export const runs = {
     return resp.tokenUsage;
   },
   countTimelineEvents: async (
+    organizationId: string,
     filter: { traceId: Uint8Array; statuses?: SpanStatus[] },
     types: RunEventType[],
   ): Promise<number> => {
@@ -385,6 +387,7 @@ export const runs = {
     let pageToken = '';
     do {
       const resp = await tracingClient.listSpans({
+        organizationId,
         filter,
         pageSize: 250,
         orderBy: ListSpansOrderBy.START_TIME_DESC,

--- a/src/api/modules/runs.ts
+++ b/src/api/modules/runs.ts
@@ -27,16 +27,19 @@ import type {
 } from '@/api/types/agents';
 import { ListSpansOrderBy, SpanStatus, TraceStatus } from '@/gen/agynio/api/tracing/v1/tracing_pb';
 
-const EVENT_TYPE_TO_SPAN_NAME: Record<RunEventType, string> =
+const EVENT_TYPE_TO_SPAN_NAME: Partial<Record<RunEventType, string>> =
   (Object.entries(SPAN_NAME_TO_EVENT_TYPE) as Array<[string, RunEventType]>).reduce(
     (acc, [spanName, eventType]) => {
       acc[eventType] = spanName;
       return acc;
     },
-    {} as Record<RunEventType, string>,
+    {} as Partial<Record<RunEventType, string>>,
   );
 
-const RUN_EVENT_TYPES = new Set<RunEventType>(Object.keys(EVENT_TYPE_TO_SPAN_NAME) as RunEventType[]);
+const RUN_EVENT_TYPES = new Set<RunEventType>([
+  ...Object.keys(EVENT_TYPE_TO_SPAN_NAME) as RunEventType[],
+  'unsupported',
+]);
 const RUN_EVENT_STATUSES = new Set<RunEventStatus>(['pending', 'running', 'success', 'error', 'cancelled']);
 
 const EMPTY_COUNTS_BY_TYPE: Record<RunEventType, number> = {
@@ -45,6 +48,7 @@ const EMPTY_COUNTS_BY_TYPE: Record<RunEventType, number> = {
   llm_call: 0,
   tool_execution: 0,
   summarization: 0,
+  unsupported: 0,
 };
 
 const EMPTY_COUNTS_BY_STATUS: Record<RunEventStatus, number> = {
@@ -104,9 +108,8 @@ function requireSummary(summary: RunTimelineSummary | undefined, runId: string):
 function mapCountsByName(countsByName: Record<string, bigint>): Record<RunEventType, number> {
   const counts = { ...EMPTY_COUNTS_BY_TYPE };
   for (const [key, value] of Object.entries(countsByName)) {
-    const type = SPAN_NAME_TO_EVENT_TYPE[key];
-    if (!type) continue;
-    counts[type] = Number(value);
+    const type = SPAN_NAME_TO_EVENT_TYPE[key] ?? 'unsupported';
+    counts[type] = (counts[type] ?? 0) + Number(value);
   }
   return counts;
 }
@@ -129,10 +132,11 @@ function mapCountsByStatus(countsByStatus: Record<string, bigint>): Record<RunEv
   return counts;
 }
 
-function mapEventTypesToSpanNames(types: RunEventType[]): string[] {
+function mapEventTypesToSpanNames(types: RunEventType[]): string[] | null {
+  if (types.includes('unsupported')) return null;
   const spanNames: string[] = [];
   for (const type of types) {
-    const mapped = EVENT_TYPE_TO_SPAN_NAME[type as RunEventType];
+    const mapped = EVENT_TYPE_TO_SPAN_NAME[type];
     if (mapped) spanNames.push(mapped);
   }
   return spanNames;
@@ -274,7 +278,8 @@ export const runs = {
     };
     const types = parseEventTypes(params.types);
     if (types.length > 0) {
-      filter.names = mapEventTypesToSpanNames(types);
+      const spanNames = mapEventTypesToSpanNames(types);
+      if (spanNames) filter.names = spanNames;
     }
     const statuses = parseEventStatuses(params.statuses);
     if (statuses.length > 0) {
@@ -309,7 +314,10 @@ export const runs = {
       traceId: hexToBytes(runId),
     };
     const types = parseEventTypes(params?.types);
-    if (types.length > 0) req.names = mapEventTypesToSpanNames(types);
+    if (types.length > 0) {
+      const spanNames = mapEventTypesToSpanNames(types);
+      if (spanNames) req.names = spanNames;
+    }
     const statuses = parseEventStatuses(params?.statuses);
     if (statuses.length > 0) {
       const spanStatuses = mapEventStatusesToSpanStatuses(statuses);

--- a/src/api/spanToEvent.ts
+++ b/src/api/spanToEvent.ts
@@ -1,6 +1,7 @@
-import type { AnyValue, KeyValue } from '@/gen/opentelemetry/proto/common/v1/common_pb';
+import { toJson } from '@bufbuild/protobuf';
+import { KeyValueSchema, type AnyValue, type KeyValue } from '@/gen/opentelemetry/proto/common/v1/common_pb';
 import type { ResourceSpans, Span } from '@/gen/opentelemetry/proto/trace/v1/trace_pb';
-import { Status_StatusCode } from '@/gen/opentelemetry/proto/trace/v1/trace_pb';
+import { SpanSchema, Span_SpanKind, Status_StatusCode } from '@/gen/opentelemetry/proto/trace/v1/trace_pb';
 import type { RunEventStatus, RunEventType, RunTimelineEvent } from '@/api/types/agents';
 
 type FlattenedSpan = { span: Span; resourceAttrs: KeyValue[] };
@@ -12,6 +13,8 @@ export const SPAN_NAME_TO_EVENT_TYPE: Record<string, RunEventType> = {
   'tool.execution': 'tool_execution',
   summarization: 'summarization',
 };
+
+const UNSUPPORTED_EVENT_TYPE: RunEventType = 'unsupported';
 
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
@@ -84,11 +87,7 @@ export function nanosToDurationMs(start: bigint, end: bigint): number | null {
 }
 
 function mapSpanNameToEventType(name: string): RunEventType {
-  const type = SPAN_NAME_TO_EVENT_TYPE[name];
-  if (!type) {
-    throw new Error(`Unhandled span name: ${name}`);
-  }
-  return type;
+  return SPAN_NAME_TO_EVENT_TYPE[name] ?? UNSUPPORTED_EVENT_TYPE;
 }
 
 type ToolCallPayload = {
@@ -124,6 +123,66 @@ function parseToolCalls(raw: string | null): Array<{ callId: string; name: strin
       arguments: toolCall.arguments ?? null,
     };
   });
+}
+
+function spanKindLabel(kind: Span_SpanKind): string {
+  switch (kind) {
+    case Span_SpanKind.UNSPECIFIED:
+      return 'unspecified';
+    case Span_SpanKind.INTERNAL:
+      return 'internal';
+    case Span_SpanKind.SERVER:
+      return 'server';
+    case Span_SpanKind.CLIENT:
+      return 'client';
+    case Span_SpanKind.PRODUCER:
+      return 'producer';
+    case Span_SpanKind.CONSUMER:
+      return 'consumer';
+    default:
+      throw new Error(`Unhandled span kind: ${kind}`);
+  }
+}
+
+function spanStatusCodeLabel(code: Status_StatusCode | undefined): string {
+  switch (code ?? Status_StatusCode.UNSET) {
+    case Status_StatusCode.UNSET:
+      return 'unset';
+    case Status_StatusCode.OK:
+      return 'ok';
+    case Status_StatusCode.ERROR:
+      return 'error';
+    default:
+      throw new Error(`Unhandled span status code: ${code}`);
+  }
+}
+
+function keyValuesToJson(attrs: KeyValue[]): unknown[] {
+  return attrs.map((attr) => toJson(KeyValueSchema, attr));
+}
+
+function extractUnsupportedSpan(
+  span: Span,
+  resourceAttrs: KeyValue[],
+  traceIdHex: string,
+  spanIdHex: string,
+) {
+  const parentSpanId = bytesToHex(span.parentSpanId);
+
+  return {
+    spanName: span.name,
+    spanKind: spanKindLabel(span.kind),
+    spanStatus: {
+      code: spanStatusCodeLabel(span.status?.code),
+      message: span.status?.message || null,
+    },
+    traceId: traceIdHex,
+    spanId: spanIdHex,
+    parentSpanId: parentSpanId || null,
+    resourceAttributes: keyValuesToJson(resourceAttrs),
+    spanAttributes: keyValuesToJson(span.attributes),
+    rawSpan: toJson(SpanSchema, span, { alwaysEmitImplicit: true, useProtoFieldName: true }),
+  };
 }
 
 function extractLlmCall(span: Span) {
@@ -232,6 +291,9 @@ export function spanToEvent(span: Span, resourceAttrs?: KeyValue[]): RunTimeline
       break;
     case 'invocation_message':
       base.message = extractMessage(span);
+      break;
+    case 'unsupported':
+      base.unsupported = extractUnsupportedSpan(span, resourceAttrs ?? [], traceIdHex, spanIdHex);
       break;
   }
 

--- a/src/api/types/agents.ts
+++ b/src/api/types/agents.ts
@@ -33,7 +33,7 @@ export type LlmContextPage = {
 
 export type LlmContextDeltaStatus = 'available' | 'empty' | 'unavailable' | 'redacted' | 'first_call' | 'unknown';
 
-export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization';
+export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization' | 'unsupported';
 export type RunEventStatus = 'pending' | 'running' | 'success' | 'error' | 'cancelled';
 export type EventSourceKind = 'internal' | 'tracing';
 export type ToolExecStatus = 'success' | 'error';
@@ -121,6 +121,20 @@ export type RunTimelineEvent = {
     text: string | null;
     source: unknown;
     createdAt: string;
+  };
+  unsupported?: {
+    spanName: string;
+    spanKind: string;
+    spanStatus: {
+      code: string;
+      message: string | null;
+    };
+    traceId: string;
+    spanId: string;
+    parentSpanId: string | null;
+    resourceAttributes: unknown;
+    spanAttributes: unknown;
+    rawSpan: unknown;
   };
   attachments: Array<{
     id: string;

--- a/src/components/JsonViewer.tsx
+++ b/src/components/JsonViewer.tsx
@@ -4,9 +4,10 @@ import { ChevronRight, ChevronDown } from 'lucide-react';
 interface JsonViewerProps {
   data: unknown;
   className?: string;
+  initiallyExpanded?: boolean;
 }
 
-export function JsonViewer({ data, className = '' }: JsonViewerProps) {
+export function JsonViewer({ data, className = '', initiallyExpanded = true }: JsonViewerProps) {
   const isPlainObject = (value: unknown): value is Record<string, unknown> =>
     typeof value === 'object' && value !== null && !Array.isArray(value);
 
@@ -28,7 +29,9 @@ export function JsonViewer({ data, className = '' }: JsonViewerProps) {
     return paths;
   };
 
-  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(getAllPaths(data)));
+  const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() =>
+    initiallyExpanded ? new Set(getAllPaths(data)) : new Set(),
+  );
 
   const togglePath = (path: string) => {
     const newExpanded = new Set(expandedPaths);

--- a/src/components/RunEventDetails.tsx
+++ b/src/components/RunEventDetails.tsx
@@ -1,4 +1,4 @@
-import { Clock, MessageSquare, Bot, Brain, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings } from 'lucide-react';
+import { Clock, MessageSquare, Bot, Brain, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings, CircleHelp } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useToolOutputStreaming } from '@/hooks/useToolOutputStreaming';
 import { IconButton } from './IconButton';
@@ -186,6 +186,64 @@ const extractReasoningMetrics = (
 };
 
 const CONTEXT_PAGINATION_PAGE_SIZE = 20;
+const MAX_UNSUPPORTED_JSON_DEPTH = 5;
+const MAX_UNSUPPORTED_JSON_ITEMS = 120;
+const MAX_UNSUPPORTED_STRING_LENGTH = 2000;
+const REDACTED_VALUE = '[REDACTED]';
+const TRUNCATED_VALUE = '[TRUNCATED]';
+
+const SECRET_KEY_NAMES = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'api_key',
+  'token',
+  'access_token',
+  'refresh_token',
+  'password',
+  'secret',
+  'credential',
+]);
+
+const shouldRedactKey = (key: string): boolean => SECRET_KEY_NAMES.has(key.toLowerCase());
+
+const redactAndBoundJson = (value: unknown): unknown => {
+  let itemCount = 0;
+  const walk = (current: unknown, depth: number): unknown => {
+    itemCount += 1;
+    if (itemCount > MAX_UNSUPPORTED_JSON_ITEMS) return TRUNCATED_VALUE;
+    if (current === null || current === undefined) return current;
+    if (typeof current === 'string') {
+      return current.length > MAX_UNSUPPORTED_STRING_LENGTH
+        ? `${current.slice(0, MAX_UNSUPPORTED_STRING_LENGTH)}…`
+        : current;
+    }
+    if (typeof current !== 'object') return current;
+    if (depth >= MAX_UNSUPPORTED_JSON_DEPTH) return TRUNCATED_VALUE;
+    if (Array.isArray(current)) {
+      return current.slice(0, MAX_UNSUPPORTED_JSON_ITEMS).map((item) => walk(item, depth + 1));
+    }
+
+    const record = current as Record<string, unknown>;
+    if (typeof record.key === 'string' && shouldRedactKey(record.key)) {
+      return { ...record, value: REDACTED_VALUE };
+    }
+
+    const boundedRecord: Record<string, unknown> = {};
+    for (const [key, entryValue] of Object.entries(record)) {
+      if (shouldRedactKey(key)) {
+        boundedRecord[key] = REDACTED_VALUE;
+      } else {
+        boundedRecord[key] = walk(entryValue, depth + 1);
+      }
+      if (itemCount > MAX_UNSUPPORTED_JSON_ITEMS) break;
+    }
+    return boundedRecord;
+  };
+
+  return walk(value, 0);
+};
 
 export interface RunEventData extends Record<string, unknown> {
   messageSubtype?: MessageSubtype;
@@ -220,9 +278,25 @@ export interface RunEventData extends Record<string, unknown> {
     status?: ContextDeltaStatus;
   };
   contextDeltaStatus?: ContextDeltaStatus;
+  startedAt?: string | null;
+  endedAt?: string | null;
+  unsupported?: {
+    spanName: string;
+    spanKind: string;
+    spanStatus: {
+      code: string;
+      message: string | null;
+    };
+    traceId: string;
+    spanId: string;
+    parentSpanId: string | null;
+    resourceAttributes: unknown;
+    spanAttributes: unknown;
+    rawSpan: unknown;
+  };
 }
 
-export type EventType = 'message' | 'llm' | 'tool' | 'summarization';
+export type EventType = 'message' | 'llm' | 'tool' | 'summarization' | 'unsupported';
 export type ToolSubtype = 'generic' | 'shell' | 'manage' | string;
 export type MessageSubtype = 'source' | 'intermediate' | 'result';
 export type OutputViewMode = 'text' | 'terminal' | 'markdown' | 'json' | 'yaml';
@@ -1264,6 +1338,89 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
     );
   };
 
+  const renderUnsupportedEvent = () => {
+    const unsupported = event.data.unsupported;
+    const rawSpan = redactAndBoundJson(unsupported?.rawSpan ?? null);
+    const resourceAttributes = redactAndBoundJson(unsupported?.resourceAttributes ?? []);
+    const spanAttributes = redactAndBoundJson(unsupported?.spanAttributes ?? []);
+
+    const metadataRows = [
+      ['Span name', unsupported?.spanName ?? 'Unknown'],
+      ['Kind', unsupported?.spanKind ?? 'unknown'],
+      ['Status', unsupported?.spanStatus.message
+        ? `${unsupported.spanStatus.code}: ${unsupported.spanStatus.message}`
+        : unsupported?.spanStatus.code ?? event.status ?? 'unknown'],
+      ['Started', asString(event.data.startedAt, event.timestamp)],
+      ['Ended', asString(event.data.endedAt, '—')],
+      ['Duration', event.duration ?? '—'],
+      ['Trace ID', unsupported?.traceId ?? '—'],
+      ['Span ID', unsupported?.spanId ?? event.id],
+      ['Parent span ID', unsupported?.parentSpanId ?? '—'],
+    ];
+
+    return (
+      <div className="space-y-6 h-full flex flex-col">
+        <div className="flex items-start flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-[var(--agyn-gray)]/10 flex items-center justify-center">
+              <CircleHelp className="w-5 h-5 text-[var(--agyn-gray)]" />
+            </div>
+            <div>
+              <h3 className="text-[var(--agyn-dark)] mb-1" data-testid="run-event-details-heading">Unsupported event</h3>
+              <div className="flex items-center gap-2 text-xs text-[var(--agyn-gray)]" data-testid="run-event-details-meta">
+                <Clock className="w-3 h-3" />
+                <span>{event.timestamp}</span>
+                {event.duration && (
+                  <>
+                    <span>•</span>
+                    <span>{event.duration}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[minmax(280px,360px)_1fr] gap-4 flex-1 min-h-0">
+          <div className="flex flex-col min-h-0 min-w-0 space-y-4">
+            <div className="border border-[var(--agyn-border-subtle)] rounded-[10px] p-4">
+              <div className="text-sm text-[var(--agyn-gray)] mb-3">Span metadata</div>
+              <div className="space-y-2">
+                {metadataRows.map(([label, value]) => (
+                  <div key={label} className="text-sm">
+                    <div className="text-[var(--agyn-gray)]">{label}</div>
+                    <div className="text-[var(--agyn-dark)] font-mono break-all">{value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="grid grid-rows-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)] gap-4 min-h-0 min-w-0">
+            <div className="flex flex-col min-h-0 min-w-0">
+              <div className="text-sm text-[var(--agyn-gray)] mb-3 h-8 flex-shrink-0">Resource attributes</div>
+              <div className="flex-1 overflow-y-auto min-h-0 border border-[var(--agyn-border-subtle)] rounded-[10px] p-4">
+                <JsonViewer data={resourceAttributes} initiallyExpanded={false} />
+              </div>
+            </div>
+            <div className="flex flex-col min-h-0 min-w-0">
+              <div className="text-sm text-[var(--agyn-gray)] mb-3 h-8 flex-shrink-0">Span attributes</div>
+              <div className="flex-1 overflow-y-auto min-h-0 border border-[var(--agyn-border-subtle)] rounded-[10px] p-4">
+                <JsonViewer data={spanAttributes} initiallyExpanded={false} />
+              </div>
+            </div>
+            <div className="flex flex-col min-h-0 min-w-0">
+              <div className="text-sm text-[var(--agyn-gray)] mb-3 h-8 flex-shrink-0">Raw span JSON</div>
+              <div className="flex-1 overflow-y-auto min-h-0 border border-[var(--agyn-border-subtle)] rounded-[10px] p-4">
+                <JsonViewer data={rawSpan} initiallyExpanded={false} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const renderSummarizationEvent = () => {
     const oldContext = Array.isArray(event.data.oldContext) ? event.data.oldContext : [];
     const newContext = Array.isArray(event.data.newContext) ? event.data.newContext : [];
@@ -1343,6 +1500,7 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
         {event.type === 'llm' && renderLLMEvent()}
         {event.type === 'tool' && renderToolEvent()}
         {event.type === 'summarization' && renderSummarizationEvent()}
+        {event.type === 'unsupported' && renderUnsupportedEvent()}
       </div>
     </div>
   );

--- a/src/components/RunEventsList.tsx
+++ b/src/components/RunEventsList.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { MessageSquare, Bot, Wrench, FileText, Terminal, Users, Loader2 } from 'lucide-react';
+import { MessageSquare, Bot, Wrench, FileText, Terminal, Users, Loader2, CircleHelp } from 'lucide-react';
 import { type EventType, type MessageSubtype, type RunEventData } from './RunEventDetails';
 import { StatusIndicator, type Status } from './StatusIndicator';
 
@@ -47,6 +47,8 @@ export function RunEventsList({
         return <Wrench className="w-4 h-4 text-[var(--agyn-cyan)]" />;
       case 'summarization':
         return <FileText className="w-4 h-4 text-[var(--agyn-gray)]" />;
+      case 'unsupported':
+        return <CircleHelp className="w-4 h-4 text-[var(--agyn-gray)]" />;
     }
   };
 
@@ -59,6 +61,8 @@ export function RunEventsList({
       case 'tool':
         return 'bg-[var(--agyn-cyan)]/10 border-[var(--agyn-cyan)]/20';
       case 'summarization':
+        return 'bg-[var(--agyn-gray)]/10 border-[var(--agyn-gray)]/20';
+      case 'unsupported':
         return 'bg-[var(--agyn-gray)]/10 border-[var(--agyn-gray)]/20';
     }
   };
@@ -85,8 +89,8 @@ export function RunEventsList({
         return event.data?.toolName || 'Tool Call';
       case 'summarization':
         return 'Summarization';
-      default:
-        return 'Event';
+      case 'unsupported':
+        return 'Unsupported event';
     }
   };
 

--- a/src/components/screens/RunScreen.tsx
+++ b/src/components/screens/RunScreen.tsx
@@ -11,6 +11,7 @@ import {
   ScrollText,
   Settings2,
   Wrench,
+  CircleHelp,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { IconButton } from '../IconButton';
@@ -27,7 +28,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 
-export type EventFilter = 'message' | 'llm' | 'tool' | 'summary';
+export type EventFilter = 'message' | 'llm' | 'tool' | 'summary' | 'unsupported';
 export type StatusFilter = 'running' | 'finished' | 'failed';
 
 interface RunScreenProps {
@@ -41,6 +42,7 @@ interface RunScreenProps {
     llm: number;
     tools: number;
     summaries: number;
+    unsupported: number;
   };
   tokens: {
     input: number;
@@ -531,6 +533,26 @@ export default function RunScreen({
                             </span>
                           </div>
                           {eventFilterSet.has('summary') ? (
+                            <Eye className="h-4 w-4 text-[var(--agyn-blue)]" />
+                          ) : (
+                            <EyeOff className="h-4 w-4 text-[var(--agyn-text-subtle)]" />
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-[var(--agyn-bg-light)] focus:bg-[var(--agyn-bg-light)]"
+                          onSelect={(event) => {
+                            event.preventDefault();
+                            handleToggleEventFilter('unsupported');
+                          }}
+                        >
+                          <div className="flex items-center gap-2">
+                            <CircleHelp className="h-4 w-4 text-[var(--agyn-gray)]" />
+                            <span>Unsupported</span>
+                            <span className="text-xs text-[var(--agyn-text-subtle)]">
+                              ({formatNumber(statistics.unsupported)})
+                            </span>
+                          </div>
+                          {eventFilterSet.has('unsupported') ? (
                             <Eye className="h-4 w-4 text-[var(--agyn-blue)]" />
                           ) : (
                             <EyeOff className="h-4 w-4 text-[var(--agyn-text-subtle)]" />

--- a/src/hooks/useTimelinePagination.ts
+++ b/src/hooks/useTimelinePagination.ts
@@ -200,6 +200,7 @@ export function useTimelinePagination({
   useEffect(() => {
     if (!eventsQuery.data) return;
     const incoming = eventsQuery.data.items ?? [];
+    const visibleIncoming = incoming.filter((event) => matchesFilters(event, selectedTypes, selectedStatuses));
     const queryCursor = eventsQuery.data.nextCursor ?? null;
 
     setLoadOlderError(null);
@@ -208,8 +209,8 @@ export function useTimelinePagination({
       setEvents([]);
       replaceEventsRef.current = false;
     }
-    if (incoming.length > 0) {
-      updateEventsState(incoming);
+    if (visibleIncoming.length > 0) {
+      updateEventsState(visibleIncoming);
     }
     if (!queryCursor) {
       reachedHistoryEndRef.current = true;
@@ -221,7 +222,7 @@ export function useTimelinePagination({
         return compareCursors(queryCursor, prev) < 0 ? queryCursor : prev;
       });
     }
-  }, [eventsQuery.data, updateEventsState, updateOlderCursor]);
+  }, [eventsQuery.data, selectedTypes, selectedStatuses, updateEventsState, updateOlderCursor]);
 
   const loadOlderEvents = useCallback(async () => {
     if (!runId || !organizationId) return;
@@ -247,7 +248,7 @@ export function useTimelinePagination({
         updateOlderCursor(null);
         return;
       }
-      const items = response.items ?? [];
+      const items = (response.items ?? []).filter((event) => matchesFilters(event, currentApiTypes, currentApiStatuses));
       if (response.nextCursor) {
         reachedHistoryEndRef.current = false;
         updateOlderCursor(response.nextCursor);

--- a/src/lib/eventMapping.ts
+++ b/src/lib/eventMapping.ts
@@ -232,6 +232,19 @@ export function createUiEvent(event: RunTimelineEvent, options?: CreateUiEventOp
         },
       };
     }
+    case 'unsupported':
+      return {
+        id: event.id,
+        type: 'unsupported',
+        timestamp,
+        duration,
+        status,
+        data: {
+          unsupported: event.unsupported,
+          startedAt: event.startedAt,
+          endedAt: event.endedAt,
+        },
+      };
     default:
       return assertNever(event.type);
   }

--- a/src/pages/AgentsRunScreen.tsx
+++ b/src/pages/AgentsRunScreen.tsx
@@ -19,9 +19,9 @@ import { toContextRecord } from '@/lib/llmContext';
 import { buildToolLinkData } from '@/lib/toolDataParsing';
 import { formatDuration } from '@/components/agents/runTimelineFormatting';
 
-const EVENT_FILTER_OPTIONS: EventFilter[] = ['message', 'llm', 'tool', 'summary'];
+const EVENT_FILTER_OPTIONS: EventFilter[] = ['message', 'llm', 'tool', 'summary', 'unsupported'];
 const STATUS_FILTER_OPTIONS: StatusFilter[] = ['running', 'finished', 'failed'];
-const API_EVENT_TYPES: RunEventType[] = ['invocation_message', 'injection', 'llm_call', 'tool_execution', 'summarization'];
+const API_EVENT_TYPES: RunEventType[] = ['invocation_message', 'injection', 'llm_call', 'tool_execution', 'summarization', 'unsupported'];
 const API_EVENT_STATUSES: RunEventStatus[] = ['running', 'success', 'error'];
 const LLM_CONTEXT_PAGE_LIMIT = 100;
 
@@ -38,6 +38,7 @@ const EVENT_FILTER_TO_TYPES: Record<EventFilter, RunEventType[]> = {
   llm: ['llm_call'],
   tool: ['tool_execution'],
   summary: ['summarization'],
+  unsupported: ['unsupported'],
 };
 
 const STATUS_FILTER_TO_STATUSES: Record<StatusFilter, RunEventStatus[]> = {
@@ -525,6 +526,7 @@ export function AgentsRunScreen() {
         llm: 0,
         tools: 0,
         summaries: 0,
+        unsupported: 0,
       };
     }
     const counts = summary.countsByType ?? {};
@@ -534,6 +536,7 @@ export function AgentsRunScreen() {
       llm: counts.llm_call ?? 0,
       tools: counts.tool_execution ?? 0,
       summaries: counts.summarization ?? 0,
+      unsupported: counts.unsupported ?? 0,
     };
   }, [filteredEventCount, runSummary]);
 

--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -1,8 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { runs } from '@/api/modules/runs';
-import { messageRunRedirectRefetchInterval } from '@/pages/utils/messageRedirectPolling';
+import { messageRunLookupTimedOut, messageRunRedirectRefetchInterval } from '@/pages/utils/messageRedirectPolling';
 
 export function MessageRedirectScreen() {
   const navigate = useNavigate();
@@ -11,14 +11,28 @@ export function MessageRedirectScreen() {
   const messageId = params.messageId;
   const resolvedMessageId = messageId ?? '';
   const organizationId = searchParams.get('orgId')?.trim() || '';
+  const [lookupStartedAtMs, setLookupStartedAtMs] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   const query = useQuery({
     enabled: Boolean(resolvedMessageId && organizationId),
     queryKey: ['runs', 'message', organizationId, resolvedMessageId],
     queryFn: () => runs.findRunByMessageId(organizationId, resolvedMessageId),
-    refetchInterval: (lookupQuery) => messageRunRedirectRefetchInterval(lookupQuery.state.data),
+    refetchInterval: (lookupQuery) =>
+      messageRunRedirectRefetchInterval(lookupQuery.state.data, lookupStartedAtMs, Date.now()),
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    setLookupStartedAtMs(Date.now());
+    setNowMs(Date.now());
+  }, [organizationId, resolvedMessageId]);
+
+  useEffect(() => {
+    if (query.data?.runId || messageRunLookupTimedOut(lookupStartedAtMs, nowMs)) return;
+    const timeoutId = window.setTimeout(() => setNowMs(Date.now()), 1000);
+    return () => window.clearTimeout(timeoutId);
+  }, [lookupStartedAtMs, nowMs, query.data?.runId]);
 
   useEffect(() => {
     if (!organizationId || !query.data?.runId) return;
@@ -58,6 +72,26 @@ export function MessageRedirectScreen() {
   }
 
   if (!query.data?.runId) {
+    if (messageRunLookupTimedOut(lookupStartedAtMs, nowMs)) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-sm text-[var(--agyn-text-subtle)]">
+          <div>No run found for message.</div>
+          <button
+            type="button"
+            className="text-[var(--agyn-blue)] hover:text-[var(--agyn-blue)]/80"
+            onClick={() => {
+              const restartedAtMs = Date.now();
+              setLookupStartedAtMs(restartedAtMs);
+              setNowMs(restartedAtMs);
+              void query.refetch();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-[var(--agyn-text-subtle)]">
         Resolving message...

--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { runs } from '@/api/modules/runs';
+import { messageRunRedirectRefetchInterval } from '@/pages/utils/messageRedirectPolling';
 
 export function MessageRedirectScreen() {
   const navigate = useNavigate();
@@ -15,6 +16,7 @@ export function MessageRedirectScreen() {
     enabled: Boolean(resolvedMessageId && organizationId),
     queryKey: ['runs', 'message', organizationId, resolvedMessageId],
     queryFn: () => runs.findRunByMessageId(organizationId, resolvedMessageId),
+    refetchInterval: (lookupQuery) => messageRunRedirectRefetchInterval(lookupQuery.state.data),
     refetchOnWindowFocus: false,
   });
 
@@ -58,7 +60,7 @@ export function MessageRedirectScreen() {
   if (!query.data?.runId) {
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-[var(--agyn-text-subtle)]">
-        No run found for message.
+        Resolving message...
       </div>
     );
   }

--- a/src/pages/utils/messageRedirectPolling.ts
+++ b/src/pages/utils/messageRedirectPolling.ts
@@ -1,0 +1,5 @@
+export type MessageRunLookup = { runId: string } | null | undefined;
+
+export function messageRunRedirectRefetchInterval(data: MessageRunLookup): false | 1000 {
+  return data?.runId ? false : 1000;
+}

--- a/src/pages/utils/messageRedirectPolling.ts
+++ b/src/pages/utils/messageRedirectPolling.ts
@@ -1,5 +1,17 @@
+export const MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS = 1000;
+export const MESSAGE_RUN_LOOKUP_TIMEOUT_MS = 30_000;
+
 export type MessageRunLookup = { runId: string } | null | undefined;
 
-export function messageRunRedirectRefetchInterval(data: MessageRunLookup): false | 1000 {
-  return data?.runId ? false : 1000;
+export function messageRunLookupTimedOut(startedAtMs: number, nowMs: number): boolean {
+  return nowMs - startedAtMs >= MESSAGE_RUN_LOOKUP_TIMEOUT_MS;
+}
+
+export function messageRunRedirectRefetchInterval(
+  data: MessageRunLookup,
+  startedAtMs: number,
+  nowMs: number,
+): false | typeof MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS {
+  if (data?.runId) return false;
+  return messageRunLookupTimedOut(startedAtMs, nowMs) ? false : MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS;
 }

--- a/test/unit/messageRedirect.spec.ts
+++ b/test/unit/messageRedirect.spec.ts
@@ -1,13 +1,25 @@
 import { describe, expect, it } from 'vitest';
-import { messageRunRedirectRefetchInterval } from '../../src/pages/utils/messageRedirectPolling';
+import {
+  MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
+  MESSAGE_RUN_LOOKUP_TIMEOUT_MS,
+  messageRunLookupTimedOut,
+  messageRunRedirectRefetchInterval,
+} from '../../src/pages/utils/messageRedirectPolling';
 
-describe('messageRunRedirectRefetchInterval', () => {
-  it('polls until the run id is resolved', () => {
-    expect(messageRunRedirectRefetchInterval(undefined)).toBe(1000);
-    expect(messageRunRedirectRefetchInterval(null)).toBe(1000);
+describe('message redirect polling', () => {
+  it('polls until the run id is resolved within the lookup window', () => {
+    expect(messageRunRedirectRefetchInterval(undefined, 1000, 1000)).toBe(MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS);
+    expect(messageRunRedirectRefetchInterval(null, 1000, 1000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS - 1)).toBe(
+      MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
+    );
   });
 
   it('stops polling after the run id is resolved', () => {
-    expect(messageRunRedirectRefetchInterval({ runId: 'abc123' })).toBe(false);
+    expect(messageRunRedirectRefetchInterval({ runId: 'abc123' }, 1000, 1000)).toBe(false);
+  });
+
+  it('stops polling after the bounded lookup window expires', () => {
+    expect(messageRunLookupTimedOut(1000, 1000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(true);
+    expect(messageRunRedirectRefetchInterval(null, 1000, 1000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(false);
   });
 });

--- a/test/unit/messageRedirect.spec.ts
+++ b/test/unit/messageRedirect.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { messageRunRedirectRefetchInterval } from '../../src/pages/utils/messageRedirectPolling';
+
+describe('messageRunRedirectRefetchInterval', () => {
+  it('polls until the run id is resolved', () => {
+    expect(messageRunRedirectRefetchInterval(undefined)).toBe(1000);
+    expect(messageRunRedirectRefetchInterval(null)).toBe(1000);
+  });
+
+  it('stops polling after the run id is resolved', () => {
+    expect(messageRunRedirectRefetchInterval({ runId: 'abc123' })).toBe(false);
+  });
+});

--- a/test/unit/runsPagination.spec.ts
+++ b/test/unit/runsPagination.spec.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import { runs } from '../../src/api/modules/runs';
+import { SpanSchema, Span_SpanKind, StatusSchema, Status_StatusCode } from '../../src/gen/opentelemetry/proto/trace/v1/trace_pb';
+import type { Span } from '../../src/gen/opentelemetry/proto/trace/v1/trace_pb';
+
+const { listSpansMock } = vi.hoisted(() => ({
+  listSpansMock: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  tracingClient: {
+    listSpans: listSpansMock,
+  },
+}));
+
+const TRACE_ID = Uint8Array.from({ length: 16 }, (_, idx) => idx);
+const BASE_START = 1_700_000_000_000_000_000n;
+
+const buildSpan = (name: string, index: number): Span =>
+  create(SpanSchema, {
+    traceId: TRACE_ID,
+    spanId: Uint8Array.from({ length: 8 }, (_, idx) => idx + index),
+    traceState: '',
+    parentSpanId: new Uint8Array(8),
+    flags: 0,
+    name,
+    kind: Span_SpanKind.INTERNAL,
+    startTimeUnixNano: BASE_START + BigInt(index),
+    endTimeUnixNano: BASE_START + BigInt(index + 1),
+    attributes: [],
+    droppedAttributesCount: 0,
+    events: [],
+    droppedEventsCount: 0,
+    links: [],
+    droppedLinksCount: 0,
+    status: create(StatusSchema, { code: Status_StatusCode.OK, message: '' }),
+  });
+
+const resourceSpans = (spans: Span[]) => [
+  {
+    $typeName: 'opentelemetry.proto.trace.v1.ResourceSpans' as const,
+    scopeSpans: [
+      {
+        $typeName: 'opentelemetry.proto.trace.v1.ScopeSpans' as const,
+        spans,
+        schemaUrl: '',
+      },
+    ],
+    schemaUrl: '',
+  },
+];
+
+describe('runs.timelineEvents unsupported pagination', () => {
+  beforeEach(() => {
+    listSpansMock.mockReset();
+  });
+
+  it('scans raw pages until it fills a filtered unsupported page', async () => {
+    listSpansMock
+      .mockResolvedValueOnce({
+        resourceSpans: resourceSpans([buildSpan('llm.call', 1)]),
+        nextPageToken: 'raw-page-2',
+      })
+      .mockResolvedValueOnce({
+        resourceSpans: resourceSpans([buildSpan('unexpected.one', 2), buildSpan('unexpected.two', 3)]),
+        nextPageToken: 'raw-page-3',
+      });
+
+    const response = await runs.timelineEvents('org-123', '000102030405060708090a0b0c0d0e0f', {
+      types: 'unsupported',
+      limit: 2,
+      order: 'desc',
+    });
+
+    expect(response.items.map((event) => event.type)).toEqual(['unsupported', 'unsupported']);
+    expect(response.nextCursor).toEqual({ ts: response.items[1].ts, id: response.items[1].id });
+    expect(listSpansMock).toHaveBeenCalledTimes(2);
+    expect(listSpansMock).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      organizationId: 'org-123',
+      pageSize: 2,
+      pageToken: '',
+      filter: expect.not.objectContaining({ names: expect.anything() }),
+    }));
+    expect(listSpansMock).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      organizationId: 'org-123',
+      pageSize: 2,
+      pageToken: 'raw-page-2',
+    }));
+  });
+});

--- a/test/unit/spanToEvent.spec.ts
+++ b/test/unit/spanToEvent.spec.ts
@@ -219,8 +219,26 @@ describe('spanToEvent conversions', () => {
     expect(event.durationMs).toBeNull();
   });
 
-  it('throws on unknown span names', () => {
-    const span = buildSpan({ name: 'unexpected.span' });
-    expect(() => spanToEvent(span, [threadAttr])).toThrow('Unhandled span name');
+  it('maps unknown span names to unsupported events', () => {
+    const span = buildSpan({
+      name: 'unexpected.span',
+      attributes: [stringAttr('x-api-key', 'secret-key')],
+    });
+    const event = spanToEvent(span, [threadAttr]);
+
+    expect(event.type).toBe('unsupported');
+    expect(event.unsupported?.spanName).toBe('unexpected.span');
+    expect(event.unsupported?.spanKind).toBe('internal');
+    expect(event.unsupported?.spanStatus.code).toBe('ok');
+    expect(event.unsupported?.traceId).toBe(bytesToHex(TRACE_ID));
+    expect(event.unsupported?.spanId).toBe(bytesToHex(span.spanId));
+    expect(event.unsupported?.parentSpanId).toBe(bytesToHex(PARENT_SPAN_ID));
+    expect(event.unsupported?.resourceAttributes).toEqual([
+      { key: 'agyn.thread.id', value: { stringValue: 'thread-123' } },
+    ]);
+    expect(event.unsupported?.spanAttributes).toEqual([
+      { key: 'x-api-key', value: { stringValue: 'secret-key' } },
+    ]);
+    expect(event.unsupported?.rawSpan).toEqual(expect.objectContaining({ name: 'unexpected.span' }));
   });
 });


### PR DESCRIPTION
## Summary
- Maps unknown span names to the new `unsupported` run event type instead of throwing.
- Carries raw unsupported span metadata for fallback rendering.
- Renders unsupported events with neutral timeline list styling and a fallback details view with bounded, collapsed, redacted JSON.
- Leaves organization run list discovery unchanged per scope.

Closes #38

## Tests
- `corepack pnpm --config.strict-dep-builds=false test`
  - Test Files: 3 passed (3)
  - Tests: 19 passed (19)
- `corepack pnpm --config.strict-dep-builds=false lint`
  - Lint passed with no errors.
- `corepack pnpm --config.strict-dep-builds=false typecheck`
  - Typecheck passed with no errors.