### PR TITLE
Align CI with centralized E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -13,14 +16,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,5 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         env:
           E2E_SUITES: playwright-tracing-app
-          E2E_PLAYWRIGHT_TEST_ARGS: test/e2e/message-deeplink-empty.spec.ts
         with:
-          service: tracing_app
+          tag: smoke

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -31,5 +31,7 @@ jobs:
 
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
+        env:
+          E2E_SUITES: playwright-tracing-app
         with:
           service: tracing_app

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,5 +33,6 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         env:
           E2E_SUITES: playwright-tracing-app
+          E2E_PLAYWRIGHT_TEST_ARGS: test/e2e/message-deeplink-empty.spec.ts
         with:
           service: tracing_app


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy tracing-app from source with `devspace dev`, then run `agynio/e2e/.github/actions/run-tests@main`.
- Replaces the pinned bootstrap action commit with `@main`.
- Adds read-only workflow permissions to CI/E2E.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #40

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yaml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yaml` — passed with no errors.
- `pnpm lint` — passed with no errors.
- `pnpm typecheck` — passed.
- `pnpm test` — 19 passed, 0 failed, 0 skipped.
- `VITE_API_BASE_URL=/api pnpm build` — passed.