### PR TITLE
fix(message): retry trace run resolution

### DIFF
--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -3,6 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { runs } from '@/api/modules/runs';
 
+const MESSAGE_RUN_RESOLUTION_TIMEOUT_MS = 120_000;
+const MESSAGE_RUN_RESOLUTION_RETRY_MS = 2_000;
+
 export function MessageRedirectScreen() {
   const navigate = useNavigate();
   const params = useParams<{ messageId: string }>();
@@ -16,6 +19,10 @@ export function MessageRedirectScreen() {
     queryKey: ['runs', 'message', organizationId, resolvedMessageId],
     queryFn: () => runs.findRunByMessageId(organizationId, resolvedMessageId),
     refetchOnWindowFocus: false,
+    refetchInterval: (query) => (query.state.data?.runId ? false : MESSAGE_RUN_RESOLUTION_RETRY_MS),
+    refetchIntervalInBackground: true,
+    staleTime: 0,
+    gcTime: MESSAGE_RUN_RESOLUTION_TIMEOUT_MS,
   });
 
   useEffect(() => {


### PR DESCRIPTION
The chat-app trace-link E2E opens tracing-app at /message/:messageId immediately after an agent reply. The message route currently performs one ListSpans lookup and then settles on "No run found for message" if ingestion/indexing has not caught up yet.

Architecture says the message entry point should resolve spans by agyn.thread.message.id and navigate to the run when data exists. This patch keeps polling the message lookup until a run appears, so the page can handle eventual trace ingestion instead of getting stuck on the original /message URL.

Validation:
- ./node_modules/.bin/vitest run
- ./node_modules/.bin/tsc -p tsconfig.app.json --noEmit
- ./node_modules/.bin/eslint .
- ./node_modules/.bin/vite build