### PR TITLE
fix(redirect): bound message lookup polling

### DIFF
--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -1,10 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { runs } from '@/api/modules/runs';
-
-const MESSAGE_REDIRECT_REFETCH_BASE_MS = 1_000;
-const MESSAGE_REDIRECT_REFETCH_MAX_MS = 5_000;
+import { messageRunLookupTimedOut, messageRunRedirectRefetchInterval } from '@/pages/utils/messageRedirectPolling';
 
 export function MessageRedirectScreen() {
   const navigate = useNavigate();
@@ -13,21 +11,29 @@ export function MessageRedirectScreen() {
   const messageId = params.messageId;
   const resolvedMessageId = messageId ?? '';
   const organizationId = searchParams.get('orgId')?.trim() || '';
+  const [lookupStartedAtMs, setLookupStartedAtMs] = useState(() => Date.now());
+  const [nowMs, setNowMs] = useState(() => Date.now());
 
   const query = useQuery({
     enabled: Boolean(resolvedMessageId && organizationId),
     queryKey: ['runs', 'message', organizationId, resolvedMessageId],
     queryFn: () => runs.findRunByMessageId(organizationId, resolvedMessageId),
-    refetchInterval: ({ state }) => {
-      if (state.data === undefined || state.data?.runId) return false;
-
-      const nullResponseCount = state.dataUpdateCount;
-      const backoffInterval = MESSAGE_REDIRECT_REFETCH_BASE_MS * 2 ** (nullResponseCount - 1);
-      return Math.min(backoffInterval, MESSAGE_REDIRECT_REFETCH_MAX_MS);
-    },
-    refetchIntervalInBackground: true,
+    refetchInterval: (lookupQuery) =>
+      messageRunRedirectRefetchInterval(lookupQuery.state.data, lookupStartedAtMs, Date.now()),
     refetchOnWindowFocus: false,
   });
+
+  useEffect(() => {
+    const startedAtMs = Date.now();
+    setLookupStartedAtMs(startedAtMs);
+    setNowMs(startedAtMs);
+  }, [organizationId, resolvedMessageId]);
+
+  useEffect(() => {
+    if (query.data?.runId || messageRunLookupTimedOut(lookupStartedAtMs, nowMs)) return;
+    const timeoutId = window.setTimeout(() => setNowMs(Date.now()), 1_000);
+    return () => window.clearTimeout(timeoutId);
+  }, [lookupStartedAtMs, nowMs, query.data?.runId]);
 
   useEffect(() => {
     if (!organizationId || !query.data?.runId) return;
@@ -67,9 +73,29 @@ export function MessageRedirectScreen() {
   }
 
   if (!query.data?.runId) {
+    if (messageRunLookupTimedOut(lookupStartedAtMs, nowMs)) {
+      return (
+        <div className="flex flex-1 flex-col items-center justify-center gap-3 text-sm text-[var(--agyn-text-subtle)]">
+          <div>No run found for message.</div>
+          <button
+            type="button"
+            className="text-[var(--agyn-blue)] hover:text-[var(--agyn-blue)]/80"
+            onClick={() => {
+              const startedAtMs = Date.now();
+              setLookupStartedAtMs(startedAtMs);
+              setNowMs(startedAtMs);
+              void query.refetch();
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-[var(--agyn-text-subtle)]">
-        Waiting for run to appear...
+        Resolving message...
       </div>
     );
   }

--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -20,6 +20,7 @@ export function MessageRedirectScreen() {
     queryFn: () => runs.findRunByMessageId(organizationId, resolvedMessageId),
     refetchInterval: (lookupQuery) =>
       messageRunRedirectRefetchInterval(lookupQuery.state.data, lookupStartedAtMs, Date.now()),
+    refetchIntervalInBackground: true,
     refetchOnWindowFocus: false,
   });
 

--- a/src/pages/utils/messageRedirectPolling.ts
+++ b/src/pages/utils/messageRedirectPolling.ts
@@ -1,0 +1,17 @@
+export const MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS = 1_000;
+export const MESSAGE_RUN_LOOKUP_TIMEOUT_MS = 20_000;
+
+export type MessageRunLookup = { runId: string } | null | undefined;
+
+export function messageRunLookupTimedOut(startedAtMs: number, nowMs: number): boolean {
+  return nowMs - startedAtMs >= MESSAGE_RUN_LOOKUP_TIMEOUT_MS;
+}
+
+export function messageRunRedirectRefetchInterval(
+  data: MessageRunLookup,
+  startedAtMs: number,
+  nowMs: number,
+): false | typeof MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS {
+  if (data?.runId) return false;
+  return messageRunLookupTimedOut(startedAtMs, nowMs) ? false : MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS;
+}

--- a/test/unit/MessageRedirectScreen.spec.tsx
+++ b/test/unit/MessageRedirectScreen.spec.tsx
@@ -53,7 +53,7 @@ describe('MessageRedirectScreen', () => {
     findRunByMessageIdMock.mockReset();
   });
 
-  it('polls with backoff until a run is found and redirects', async () => {
+  it('polls until a run is found and redirects', async () => {
     findRunByMessageIdMock
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -64,11 +64,7 @@ describe('MessageRedirectScreen', () => {
     expect(findRunByMessageIdMock).toHaveBeenCalledTimes(1);
 
     await waitFor(() => expect(findRunByMessageIdMock).toHaveBeenCalledTimes(2), { timeout: 2_500 });
-    await new Promise((resolve) => window.setTimeout(resolve, 1_500));
-
-    expect(findRunByMessageIdMock).toHaveBeenCalledTimes(2);
-
-    await waitFor(() => expect(findRunByMessageIdMock).toHaveBeenCalledTimes(3), { timeout: 2_000 });
+    await waitFor(() => expect(findRunByMessageIdMock).toHaveBeenCalledTimes(3), { timeout: 2_500 });
     await waitFor(() => expect(getByText('run destination')).toBeTruthy());
 
     expect(findRunByMessageIdMock).toHaveBeenCalledWith('org-1', 'message-123');

--- a/test/unit/messageRedirect.spec.ts
+++ b/test/unit/messageRedirect.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
+  MESSAGE_RUN_LOOKUP_TIMEOUT_MS,
+  messageRunLookupTimedOut,
+  messageRunRedirectRefetchInterval,
+} from '../../src/pages/utils/messageRedirectPolling';
+
+describe('message redirect polling', () => {
+  it('polls until the run id is resolved within the lookup window', () => {
+    expect(messageRunRedirectRefetchInterval(undefined, 1_000, 1_000)).toBe(MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS);
+    expect(messageRunRedirectRefetchInterval(null, 1_000, 1_000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS - 1)).toBe(
+      MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
+    );
+  });
+
+  it('stops polling after the run id is resolved', () => {
+    expect(messageRunRedirectRefetchInterval({ runId: 'abc123' }, 1_000, 1_000)).toBe(false);
+  });
+
+  it('stops polling after the bounded lookup window expires', () => {
+    expect(messageRunLookupTimedOut(1_000, 1_000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(true);
+    expect(messageRunRedirectRefetchInterval(null, 1_000, 1_000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Restores the expected unknown-message empty state after a bounded lookup window.
- Keeps product correctness for eventual consistency by polling message-to-run lookup every 1s before declaring no run found.
- Adds a manual `Retry` action to restart lookup if the run appears later.
- Adds unit coverage for lookup polling and timeout behavior.

Fixes agynio/agents-orchestrator#195

## Test & Lint Summary
- `PNPM_HOME=/root/.local/share/pnpm PATH=/root/.local/share/pnpm/bin:$PATH corepack pnpm --config.strict-dep-builds=false test`
  - Test Files: 5 passed (5)
  - Tests: 23 passed (23)
- `PNPM_HOME=/root/.local/share/pnpm PATH=/root/.local/share/pnpm/bin:$PATH corepack pnpm --config.strict-dep-builds=false lint`
  - Lint passed with no errors.
- `PNPM_HOME=/root/.local/share/pnpm PATH=/root/.local/share/pnpm/bin:$PATH corepack pnpm --config.strict-dep-builds=false typecheck`
  - Typecheck passed with no errors.
- `PNPM_HOME=/root/.local/share/pnpm PATH=/root/.local/share/pnpm/bin:$PATH corepack pnpm --config.strict-dep-builds=false build`
  - Build passed.