### PR TITLE
fix(redirect): extend message lookup window

### DIFF
--- a/src/pages/MessageRedirectScreen.tsx
+++ b/src/pages/MessageRedirectScreen.tsx
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { runs } from '@/api/modules/runs';
-import { messageRunLookupTimedOut, messageRunRedirectRefetchInterval } from '@/pages/utils/messageRedirectPolling';
+import {
+  messageRunLookupEmptyStateVisible,
+  messageRunLookupTimedOut,
+  messageRunRedirectRefetchInterval,
+} from '@/pages/utils/messageRedirectPolling';
 
 export function MessageRedirectScreen() {
   const navigate = useNavigate();
@@ -74,7 +78,7 @@ export function MessageRedirectScreen() {
   }
 
   if (!query.data?.runId) {
-    if (messageRunLookupTimedOut(lookupStartedAtMs, nowMs)) {
+    if (messageRunLookupEmptyStateVisible(lookupStartedAtMs, nowMs)) {
       return (
         <div className="flex flex-1 flex-col items-center justify-center gap-3 text-sm text-[var(--agyn-text-subtle)]">
           <div>No run found for message.</div>

--- a/src/pages/utils/messageRedirectPolling.ts
+++ b/src/pages/utils/messageRedirectPolling.ts
@@ -1,10 +1,15 @@
 export const MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS = 1_000;
-export const MESSAGE_RUN_LOOKUP_TIMEOUT_MS = 20_000;
+export const MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS = 20_000;
+export const MESSAGE_RUN_LOOKUP_TIMEOUT_MS = 120_000;
 
 export type MessageRunLookup = { runId: string } | null | undefined;
 
 export function messageRunLookupTimedOut(startedAtMs: number, nowMs: number): boolean {
   return nowMs - startedAtMs >= MESSAGE_RUN_LOOKUP_TIMEOUT_MS;
+}
+
+export function messageRunLookupEmptyStateVisible(startedAtMs: number, nowMs: number): boolean {
+  return nowMs - startedAtMs >= MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS;
 }
 
 export function messageRunRedirectRefetchInterval(

--- a/test/unit/messageRedirect.spec.ts
+++ b/test/unit/messageRedirect.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS,
   MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
   MESSAGE_RUN_LOOKUP_TIMEOUT_MS,
+  messageRunLookupEmptyStateVisible,
   messageRunLookupTimedOut,
   messageRunRedirectRefetchInterval,
 } from '../../src/pages/utils/messageRedirectPolling';
@@ -21,5 +23,13 @@ describe('message redirect polling', () => {
   it('stops polling after the bounded lookup window expires', () => {
     expect(messageRunLookupTimedOut(1_000, 1_000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(true);
     expect(messageRunRedirectRefetchInterval(null, 1_000, 1_000 + MESSAGE_RUN_LOOKUP_TIMEOUT_MS)).toBe(false);
+  });
+
+  it('shows the empty state before the lookup timeout', () => {
+    expect(messageRunLookupEmptyStateVisible(1_000, 1_000 + MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS)).toBe(true);
+    expect(messageRunLookupTimedOut(1_000, 1_000 + MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS)).toBe(false);
+    expect(messageRunRedirectRefetchInterval(null, 1_000, 1_000 + MESSAGE_RUN_LOOKUP_EMPTY_STATE_MS)).toBe(
+      MESSAGE_RUN_LOOKUP_REFETCH_INTERVAL_MS,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Keep message deeplink polling active after the empty-state message is shown.
- Extend the bounded lookup window to match the full-chain E2E redirect timeout while preserving the 20s unknown-message empty state.
- Add unit coverage proving empty-state display does not stop background polling.

Closes #46

## Test & Lint Summary
- `PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm run test` — 24 passed / 0 failed / 0 skipped
- `PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm run lint` — passed with no errors
- `PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm run typecheck` — passed with no errors
- `PNPM_CONFIG_STRICT_DEP_BUILDS=false pnpm run build` — passed