### PR TITLE
Fix auth initial load 401/400 failures

### DIFF
--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -57,13 +57,23 @@ function SignedOutScreen({
   );
 }
 
+function LoadingScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-muted/40 text-sm text-muted-foreground">
+      Loading tracing...
+    </div>
+  );
+}
+
 function RequireAuth({ children }: { children: ReactNode }) {
   const auth = useAuth();
   const [signedOut, setSignedOut] = useState(() => readSignedOutFlag());
+  const [redirectPending, setRedirectPending] = useState(false);
 
   const handleSignIn = useCallback(() => {
     clearSignedOutFlag();
     setSignedOut(false);
+    setRedirectPending(true);
     void auth.signinRedirect(getSigninRedirectArgs());
   }, [auth]);
 
@@ -80,22 +90,24 @@ function RequireAuth({ children }: { children: ReactNode }) {
   }, [auth.isAuthenticated, signedOut]);
 
   useEffect(() => {
-    if (signedOut) return;
+    if (signedOut || redirectPending) return;
     if (auth.isLoading || auth.activeNavigator || auth.isAuthenticated) return;
     if (hasAuthParams()) return;
+    setRedirectPending(true);
     void auth.signinRedirect(getSigninRedirectArgs());
-  }, [auth, signedOut]);
+  }, [auth, redirectPending, signedOut]);
+
+  useEffect(() => {
+    if (!redirectPending || !auth.isAuthenticated) return;
+    setRedirectPending(false);
+  }, [auth.isAuthenticated, redirectPending]);
 
   if (signedOut && !auth.isAuthenticated) {
     return <SignedOutScreen onSignIn={handleSignIn} />;
   }
 
-  if (auth.isLoading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-muted/40 text-sm text-muted-foreground">
-        Loading tracing...
-      </div>
-    );
+  if (auth.isLoading || auth.activeNavigator || redirectPending || !auth.isAuthenticated) {
+    return <LoadingScreen />;
   }
 
   return <>{children}</>;

--- a/src/auth/auth-interceptor.ts
+++ b/src/auth/auth-interceptor.ts
@@ -13,7 +13,7 @@ export const authInterceptor: Interceptor = (next) => async (req) => {
   try {
     return await next(req);
   } catch (error) {
-    if (error instanceof ConnectError && error.code === Code.Unauthenticated && userManager) {
+    if (token && error instanceof ConnectError && error.code === Code.Unauthenticated && userManager) {
       const didRetry = req.contextValues.get(retryKey);
       if (!didRetry) {
         req.contextValues.set(retryKey, true);

--- a/test/unit/AuthGate.spec.tsx
+++ b/test/unit/AuthGate.spec.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment happy-dom
+
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { authState, signinRedirectMock } = vi.hoisted(() => ({
+  authState: {
+    isAuthenticated: false,
+    isLoading: false,
+    activeNavigator: undefined as string | undefined,
+    error: undefined as Error | undefined,
+  },
+  signinRedirectMock: vi.fn(),
+}));
+
+vi.mock('react-oidc-context', () => ({
+  AuthProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useAuth: () => ({
+    ...authState,
+    removeUser: vi.fn(),
+    signinRedirect: signinRedirectMock,
+  }),
+}));
+
+vi.mock('@/config', () => ({
+  oidcConfig: {
+    enabled: true,
+    authority: 'https://auth.test',
+    clientId: 'tracing-app',
+    scope: 'openid profile',
+  },
+}));
+
+vi.mock('@/auth/user-manager', () => ({
+  userManager: {},
+}));
+
+describe('AuthGate', () => {
+  afterEach(() => {
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+    authState.activeNavigator = undefined;
+    authState.error = undefined;
+    signinRedirectMock.mockReset();
+    window.history.replaceState({}, '', '/');
+    window.sessionStorage.clear();
+  });
+
+  it('blocks route rendering while signin redirect is pending', async () => {
+    const { AuthGate } = await import('../../src/auth/AuthGate');
+
+    render(
+      <AuthGate>
+        <div>Protected route</div>
+      </AuthGate>,
+    );
+
+    await waitFor(() => expect(signinRedirectMock).toHaveBeenCalledTimes(1));
+    expect(screen.getByText('Loading tracing...')).not.toBeNull();
+    expect(screen.queryByText('Protected route')).toBeNull();
+  });
+
+  it('renders protected routes only after authentication', async () => {
+    const { AuthGate } = await import('../../src/auth/AuthGate');
+    authState.isAuthenticated = true;
+
+    render(
+      <AuthGate>
+        <div>Protected route</div>
+      </AuthGate>,
+    );
+
+    expect(screen.getByText('Protected route')).not.toBeNull();
+    expect(signinRedirectMock).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/auth-interceptor.spec.ts
+++ b/test/unit/auth-interceptor.spec.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+
+import { Code, ConnectError, createContextValues } from '@connectrpc/connect';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { getAccessTokenMock, signinSilentMock } = vi.hoisted(() => ({
+  getAccessTokenMock: vi.fn(),
+  signinSilentMock: vi.fn(),
+}));
+
+vi.mock('@/auth/user-manager', () => ({
+  getAccessToken: getAccessTokenMock,
+  userManager: {
+    signinSilent: signinSilentMock,
+  },
+}));
+
+function createRequest() {
+  return {
+    header: new Headers(),
+    contextValues: createContextValues(),
+  };
+}
+
+describe('authInterceptor', () => {
+  afterEach(() => {
+    getAccessTokenMock.mockReset();
+    signinSilentMock.mockReset();
+  });
+
+  it('does not attempt silent renew when the request had no token', async () => {
+    const { authInterceptor } = await import('../../src/auth/auth-interceptor');
+    const unauthenticatedError = new ConnectError('missing auth', Code.Unauthenticated);
+    const next = vi.fn().mockRejectedValue(unauthenticatedError);
+    const req = createRequest();
+
+    getAccessTokenMock.mockResolvedValue(null);
+
+    await expect(authInterceptor(next)(req)).rejects.toBe(unauthenticatedError);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.header.has('Authorization')).toBe(false);
+    expect(signinSilentMock).not.toHaveBeenCalled();
+  });
+
+  it('silently renews and retries when the original token was rejected', async () => {
+    const { authInterceptor } = await import('../../src/auth/auth-interceptor');
+    const next = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('expired auth', Code.Unauthenticated))
+      .mockResolvedValueOnce('ok');
+    const req = createRequest();
+
+    getAccessTokenMock.mockResolvedValueOnce('expired-token').mockResolvedValueOnce('fresh-token');
+    signinSilentMock.mockResolvedValue(undefined);
+
+    await expect(authInterceptor(next)(req)).resolves.toBe('ok');
+
+    expect(signinSilentMock).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledTimes(2);
+    expect(req.header.get('Authorization')).toBe('Bearer fresh-token');
+  });
+});


### PR DESCRIPTION
## Summary
- Block protected route rendering while OIDC loading, navigation, or signin redirect is pending.
- Keep the signed-out screen for explicit signed-out state, but otherwise show loading until authentication exists.
- Only run `signinSilent` retry for unauthenticated API responses when the original request had an access token.
- Added unit coverage for AuthGate blocking and interceptor retry behavior.

Closes #50

## Test & Lint Summary
- `corepack pnpm@10 test`: 29 passed, 0 failed, 0 skipped.
- `corepack pnpm@10 lint`: passed with no errors.
- `corepack pnpm@10 typecheck`: passed with no errors.
- `VITE_API_BASE_URL=/api corepack pnpm@10 build`: passed.