### PR TITLE
feat(auth): request configured OIDC resource

### DIFF
--- a/charts/tracing-app/Chart.yaml
+++ b/charts/tracing-app/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: tracing-app
 description: Helm chart for deploying the agyn Tracing App.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.3.2
+appVersion: 0.3.2
 home: https://github.com/agynio/tracing-app
 sources:
   - https://github.com/agynio/tracing-app

--- a/charts/tracing-app/values.yaml
+++ b/charts/tracing-app/values.yaml
@@ -79,6 +79,8 @@ env:
     value: "{{ .Values.oidcClientId }}"
   - name: OIDC_SCOPE
     value: "{{ .Values.oidcScope }}"
+  - name: OIDC_RESOURCE
+    value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
 envFrom: []
@@ -196,6 +198,7 @@ metrics:
 oidcAuthority: ""
 oidcClientId: ""
 oidcScope: "openid profile email offline_access"
+oidcResource: ""
 apiBaseUrl: /api
 
 nginx:

--- a/src/auth/user-manager.ts
+++ b/src/auth/user-manager.ts
@@ -14,6 +14,7 @@ export const userManager = oidcConfig.enabled
       post_logout_redirect_uri: postLogoutRedirectUri,
       silent_redirect_uri: silentRedirectUri,
       scope: oidcConfig.scope,
+      resource: oidcConfig.resource ?? undefined,
       response_type: 'code',
       userStore: new WebStorageStateStore({ store: window.sessionStorage }),
       automaticSilentRenew: true,

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ type RuntimeEnv = {
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
+  OIDC_RESOURCE?: string;
 };
 
 export type OidcConfig = {
@@ -10,6 +11,7 @@ export type OidcConfig = {
   authority: string;
   clientId: string;
   scope: string;
+  resource: string | null;
 };
 
 const runtimeEnv: RuntimeEnv = window.__ENV__ ?? {};
@@ -41,12 +43,14 @@ const authority = stripTrailingSlash(
 );
 const clientId = requireConfig('OIDC_CLIENT_ID', readConfigValue('OIDC_CLIENT_ID', 'VITE_OIDC_CLIENT_ID'));
 const scope = requireConfig('OIDC_SCOPE', readConfigValue('OIDC_SCOPE', 'VITE_OIDC_SCOPE'));
+const resource = readConfigValue('OIDC_RESOURCE', 'VITE_OIDC_RESOURCE');
 
 export const oidcConfig: OidcConfig = {
   enabled: true,
   authority,
   clientId,
   scope,
+  resource,
 };
 
 export const config = {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -5,6 +5,7 @@ interface ImportMetaEnv {
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
+  readonly VITE_OIDC_RESOURCE?: string;
 }
 
 interface ImportMeta {
@@ -17,5 +18,6 @@ interface Window {
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;
+    OIDC_RESOURCE?: string;
   };
 }

--- a/test/unit/config.spec.ts
+++ b/test/unit/config.spec.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('config', () => {
+  beforeEach(() => {
+    window.__ENV__ = {
+      OIDC_AUTHORITY: 'https://auth.example.com/',
+      OIDC_CLIENT_ID: 'tracing-client',
+      OIDC_SCOPE: 'openid profile',
+    };
+    vi.resetModules();
+  });
+
+  it('defaults OIDC resource to null', async () => {
+    const { oidcConfig } = await import('../../src/config');
+
+    expect(oidcConfig.resource).toBeNull();
+  });
+
+  it('reads runtime OIDC resource', async () => {
+    window.__ENV__ = {
+      ...window.__ENV__,
+      OIDC_RESOURCE: 'https://api.example.com',
+    };
+
+    const { oidcConfig } = await import('../../src/config');
+
+    expect(oidcConfig.resource).toBe('https://api.example.com');
+  });
+});


### PR DESCRIPTION
## Summary

Supports agynio/infrastructure#22 and agynio/infrastructure#23 by making the Logto API resource indicator functional instead of an inert chart value.

This PR wires the OIDC resource/audience through this repository's runtime/chart contract so the platform chart can pass `https://agyn.cloud` from the Logto workspace outputs.

## Validation

See the parent infrastructure PR for the full cross-repository validation summary.
