### PR TITLE
Show every span, and find the run a message actually belongs to

### DIFF
--- a/src/api/modules/runs.ts
+++ b/src/api/modules/runs.ts
@@ -8,6 +8,7 @@ import {
   getStringAttr,
   hexToBytes,
   nanosToIso,
+  RAW_SPAN_EVENT_TYPE,
   SPAN_NAME_TO_EVENT_TYPE,
   spanToEvent,
 } from '@/api/spanToEvent';
@@ -36,7 +37,10 @@ const EVENT_TYPE_TO_SPAN_NAME: Record<RunEventType, string> =
     {} as Record<RunEventType, string>,
   );
 
-const RUN_EVENT_TYPES = new Set<RunEventType>(Object.keys(EVENT_TYPE_TO_SPAN_NAME) as RunEventType[]);
+const RUN_EVENT_TYPES = new Set<RunEventType>([
+  ...(Object.keys(EVENT_TYPE_TO_SPAN_NAME) as RunEventType[]),
+  RAW_SPAN_EVENT_TYPE,
+]);
 const RUN_EVENT_STATUSES = new Set<RunEventStatus>(['pending', 'running', 'success', 'error', 'cancelled']);
 
 const EMPTY_COUNTS_BY_TYPE: Record<RunEventType, number> = {
@@ -45,6 +49,7 @@ const EMPTY_COUNTS_BY_TYPE: Record<RunEventType, number> = {
   llm_call: 0,
   tool_execution: 0,
   summarization: 0,
+  span: 0,
 };
 
 const EMPTY_COUNTS_BY_STATUS: Record<RunEventStatus, number> = {
@@ -55,7 +60,8 @@ const EMPTY_COUNTS_BY_STATUS: Record<RunEventStatus, number> = {
   cancelled: 0,
 };
 
-const INVOCATION_MESSAGE_SPAN_NAME = 'invocation.message';
+const MESSAGE_SPAN_LOOKUP_PAGE_SIZE = 500;
+const ORGANIZATION_RUN_SCAN_PAGE_SIZE = 500;
 
 export type OrganizationRunSummary = {
   runId: string;
@@ -107,9 +113,8 @@ function requireSummary(summary: RunTimelineSummary | undefined, runId: string):
 function mapCountsByName(countsByName: Record<string, bigint>): Record<RunEventType, number> {
   const counts = { ...EMPTY_COUNTS_BY_TYPE };
   for (const [key, value] of Object.entries(countsByName)) {
-    const type = SPAN_NAME_TO_EVENT_TYPE[key];
-    if (!type) continue;
-    counts[type] = Number(value);
+    const type = SPAN_NAME_TO_EVENT_TYPE[key] ?? RAW_SPAN_EVENT_TYPE;
+    counts[type] += Number(value);
   }
   return counts;
 }
@@ -139,6 +144,49 @@ function mapEventTypesToSpanNames(types: RunEventType[]): string[] {
     if (mapped) spanNames.push(mapped);
   }
   return spanNames;
+}
+
+// Raw spans are defined by having no mapped name, which a name filter cannot
+// express -- selecting them means fetching the trace unfiltered.
+function spanNameFilter(types: RunEventType[]): string[] | undefined {
+  if (types.length === 0 || types.includes(RAW_SPAN_EVENT_TYPE)) return undefined;
+  const names = mapEventTypesToSpanNames(types);
+  return names.length > 0 ? names : undefined;
+}
+
+type TraceScore = { semantic: number; total: number; latest: bigint };
+
+function scoresBetter(candidate: TraceScore, best: TraceScore): boolean {
+  if (candidate.semantic !== best.semantic) return candidate.semantic > best.semantic;
+  if (candidate.total !== best.total) return candidate.total > best.total;
+  return candidate.latest > best.latest;
+}
+
+// One message can span several traces -- retries open a new one each attempt,
+// and the session-lifecycle trace outlives them all. Picking the newest span
+// lands on that lifecycle trace, so score by real content instead.
+function pickRunTrace(
+  spans: Array<{ span: { traceId: Uint8Array; name: string; startTimeUnixNano: bigint } }>,
+): string {
+  const byTrace = new Map<string, TraceScore>();
+  for (const { span } of spans) {
+    const traceId = bytesToHex(span.traceId);
+    const score = byTrace.get(traceId) ?? { semantic: 0, total: 0, latest: 0n };
+    score.total += 1;
+    if (SPAN_NAME_TO_EVENT_TYPE[span.name]) score.semantic += 1;
+    if (span.startTimeUnixNano > score.latest) score.latest = span.startTimeUnixNano;
+    byTrace.set(traceId, score);
+  }
+
+  let bestId = '';
+  let best: TraceScore | null = null;
+  for (const [traceId, score] of byTrace) {
+    if (!best || scoresBetter(score, best)) {
+      best = score;
+      bestId = traceId;
+    }
+  }
+  return bestId;
 }
 
 function mapEventStatusesToSpanStatuses(statuses: RunEventStatus[]): SpanStatus[] {
@@ -190,10 +238,11 @@ export const runs = {
     organizationId: string,
     params?: { limit?: number },
   ): Promise<OrganizationRunSummary[]> => {
+    // Scanned unfiltered: runs are traces, and a trace need not contain any
+    // span the semantic adapter recognises.
     const resp = await tracingClient.listSpans({
       organizationId,
-      filter: { names: [INVOCATION_MESSAGE_SPAN_NAME] },
-      pageSize: params?.limit ?? 50,
+      pageSize: ORGANIZATION_RUN_SCAN_PAGE_SIZE,
       pageToken: '',
       orderBy: ListSpansOrderBy.START_TIME_DESC,
     });
@@ -202,12 +251,14 @@ export const runs = {
     const runSpans = new Map<string, (typeof spans)[number]>();
     for (const span of spans) {
       const runId = bytesToHex(span.span.traceId);
-      if (!runSpans.has(runId)) {
+      const existing = runSpans.get(runId);
+      // Prefer a message span so the run keeps its human-readable label.
+      if (!existing || SPAN_NAME_TO_EVENT_TYPE[span.span.name] === 'invocation_message') {
         runSpans.set(runId, span);
       }
     }
 
-    const runIds = Array.from(runSpans.keys());
+    const runIds = Array.from(runSpans.keys()).slice(0, params?.limit ?? 50);
     // TODO: Avoid N+1 trace summary lookups by adding a batch summary API.
     const summaries = await Promise.all(runIds.map((runId) => runs.timelineSummary(runId)));
     const summaryById = new Map(summaries.map((summary) => [summary.runId, summary]));
@@ -215,15 +266,15 @@ export const runs = {
     return runIds.map((runId) => {
       const spanData = runSpans.get(runId);
       if (!spanData) {
-        throw new Error(`Missing invocation span for run ${runId}`);
+        throw new Error(`Missing representative span for run ${runId}`);
       }
       const summary = requireSummary(summaryById.get(runId), runId);
-      const event = spanToEvent(spanData.span, spanData.resourceAttrs);
+      const event = spanToEvent(spanData.span, spanData.resourceAttrs, spanData.scopeName);
       const startedAt = Date.parse(summary.createdAt);
       const endedAt = Date.parse(summary.updatedAt);
       return {
         runId,
-        messageText: event.message?.text ?? null,
+        messageText: event.message?.text ?? event.span?.name ?? null,
         createdAt: summary.createdAt,
         status: summary.status,
         durationMs:
@@ -241,7 +292,7 @@ export const runs = {
     let resp = await tracingClient.listSpans({
       organizationId,
       filter: { messageId },
-      pageSize: 1,
+      pageSize: MESSAGE_SPAN_LOOKUP_PAGE_SIZE,
       pageToken: '',
       orderBy: ListSpansOrderBy.START_TIME_DESC,
     });
@@ -249,15 +300,14 @@ export const runs = {
     if (spans.length === 0) {
       resp = await tracingClient.listSpans({
         organizationId,
-        filter: { names: [INVOCATION_MESSAGE_SPAN_NAME] },
-        pageSize: 500,
+        pageSize: MESSAGE_SPAN_LOOKUP_PAGE_SIZE,
         pageToken: '',
         orderBy: ListSpansOrderBy.START_TIME_DESC,
       });
       spans = flattenResourceSpans(resp.resourceSpans).filter(({ span }) => bytesToHex(span.spanId) === messageId);
     }
     if (spans.length === 0) return null;
-    return { runId: bytesToHex(spans[0].span.traceId) };
+    return { runId: pickRunTrace(spans) };
   },
   timelineSummary: async (runId: string): Promise<RunTimelineSummary> => {
     const resp = await tracingClient.getTraceSummary({
@@ -292,9 +342,9 @@ export const runs = {
     const filter: { traceId: Uint8Array; names?: string[]; statuses?: SpanStatus[] } = {
       traceId: hexToBytes(runId),
     };
-    const types = parseEventTypes(params.types);
-    if (types.length > 0) {
-      filter.names = mapEventTypesToSpanNames(types);
+    const names = spanNameFilter(parseEventTypes(params.types));
+    if (names) {
+      filter.names = names;
     }
     const statuses = parseEventStatuses(params.statuses);
     if (statuses.length > 0) {
@@ -314,7 +364,7 @@ export const runs = {
     });
 
     const spans = flattenResourceSpans(resp.resourceSpans);
-    const items = spans.map(({ span, resourceAttrs }) => spanToEvent(span, resourceAttrs));
+    const items = spans.map(({ span, resourceAttrs, scopeName }) => spanToEvent(span, resourceAttrs, scopeName));
 
     return {
       items,
@@ -328,8 +378,8 @@ export const runs = {
     const req: { traceId: Uint8Array; names?: string[]; statuses?: SpanStatus[] } = {
       traceId: hexToBytes(runId),
     };
-    const types = parseEventTypes(params?.types);
-    if (types.length > 0) req.names = mapEventTypesToSpanNames(types);
+    const names = spanNameFilter(parseEventTypes(params?.types));
+    if (names) req.names = names;
     const statuses = parseEventStatuses(params?.statuses);
     if (statuses.length > 0) {
       const spanStatuses = mapEventStatusesToSpanStatuses(statuses);

--- a/src/api/spanToEvent.ts
+++ b/src/api/spanToEvent.ts
@@ -3,7 +3,10 @@ import type { ResourceSpans, Span } from '@/gen/opentelemetry/proto/trace/v1/tra
 import { Status_StatusCode } from '@/gen/opentelemetry/proto/trace/v1/trace_pb';
 import type { RunEventStatus, RunEventType, RunTimelineEvent } from '@/api/types/agents';
 
-type FlattenedSpan = { span: Span; resourceAttrs: KeyValue[] };
+type FlattenedSpan = { span: Span; resourceAttrs: KeyValue[]; scopeName: string | null };
+
+/** Span name used when the semantic adapter has no mapping for a span. */
+export const RAW_SPAN_EVENT_TYPE: RunEventType = 'span';
 
 export const SPAN_NAME_TO_EVENT_TYPE: Record<string, RunEventType> = {
   'invocation.message': 'invocation_message',
@@ -83,12 +86,51 @@ export function nanosToDurationMs(start: bigint, end: bigint): number | null {
   return Number((end - start) / 1_000_000n);
 }
 
+// Unknown spans are kept rather than rejected: the UI shows every valid OTel
+// span, and the semantic types below are an adapter layered on top.
 function mapSpanNameToEventType(name: string): RunEventType {
-  const type = SPAN_NAME_TO_EVENT_TYPE[name];
-  if (!type) {
-    throw new Error(`Unhandled span name: ${name}`);
+  return SPAN_NAME_TO_EVENT_TYPE[name] ?? RAW_SPAN_EVENT_TYPE;
+}
+
+function anyValueToJs(value: AnyValue | undefined): unknown {
+  if (!value) return null;
+  switch (value.value.case) {
+    case 'stringValue':
+    case 'boolValue':
+    case 'doubleValue':
+      return value.value.value;
+    case 'intValue':
+      return Number(value.value.value);
+    case 'bytesValue':
+      return bytesToHex(value.value.value);
+    case 'arrayValue':
+      return value.value.value.values.map((entry) => anyValueToJs(entry));
+    case 'kvlistValue':
+      return attrsToRecord(value.value.value.values);
+    default:
+      return null;
   }
-  return type;
+}
+
+export function attrsToRecord(attrs: KeyValue[]): Record<string, unknown> {
+  const record: Record<string, unknown> = {};
+  for (const attr of attrs) {
+    record[attr.key] = anyValueToJs(attr.value);
+  }
+  return record;
+}
+
+function extractRawSpan(span: Span, resourceAttrs: KeyValue[], scopeName: string | null) {
+  const parentSpanId = span.parentSpanId.length > 0 ? bytesToHex(span.parentSpanId) : null;
+  return {
+    name: span.name,
+    kind: span.kind,
+    spanId: bytesToHex(span.spanId),
+    parentSpanId,
+    scopeName,
+    attributes: attrsToRecord(span.attributes),
+    resourceAttributes: attrsToRecord(resourceAttrs),
+  };
 }
 
 type ToolCallPayload = {
@@ -190,7 +232,7 @@ function extractMessage(span: Span) {
   };
 }
 
-export function spanToEvent(span: Span, resourceAttrs?: KeyValue[]): RunTimelineEvent {
+export function spanToEvent(span: Span, resourceAttrs?: KeyValue[], scopeName?: string | null): RunTimelineEvent {
   const attrs = span.attributes;
   const spanName = span.name;
   const status = deriveEventStatus(span);
@@ -233,6 +275,9 @@ export function spanToEvent(span: Span, resourceAttrs?: KeyValue[]): RunTimeline
     case 'invocation_message':
       base.message = extractMessage(span);
       break;
+    case 'span':
+      base.span = extractRawSpan(span, resourceAttrs ?? [], scopeName ?? null);
+      break;
   }
 
   return base;
@@ -243,8 +288,9 @@ export function flattenResourceSpans(resourceSpans: ResourceSpans[]): FlattenedS
   for (const resourceSpan of resourceSpans) {
     const resourceAttrs = resourceSpan.resource?.attributes ?? [];
     for (const scopeSpan of resourceSpan.scopeSpans) {
+      const scopeName = scopeSpan.scope?.name || null;
       for (const span of scopeSpan.spans) {
-        flattened.push({ span, resourceAttrs });
+        flattened.push({ span, resourceAttrs, scopeName });
       }
     }
   }

--- a/src/api/types/agents.ts
+++ b/src/api/types/agents.ts
@@ -33,7 +33,8 @@ export type LlmContextPage = {
 
 export type LlmContextDeltaStatus = 'available' | 'empty' | 'unavailable' | 'redacted' | 'first_call' | 'unknown';
 
-export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization';
+/** `span` carries any OTel span the semantic adapter does not recognise. */
+export type RunEventType = 'invocation_message' | 'injection' | 'llm_call' | 'tool_execution' | 'summarization' | 'span';
 export type RunEventStatus = 'pending' | 'running' | 'success' | 'error' | 'cancelled';
 export type EventSourceKind = 'internal' | 'tracing';
 export type ToolExecStatus = 'success' | 'error';
@@ -121,6 +122,15 @@ export type RunTimelineEvent = {
     text: string | null;
     source: unknown;
     createdAt: string;
+  };
+  span?: {
+    name: string;
+    kind: number;
+    spanId: string;
+    parentSpanId: string | null;
+    scopeName: string | null;
+    attributes: Record<string, unknown>;
+    resourceAttributes: Record<string, unknown>;
   };
   attachments: Array<{
     id: string;

--- a/src/components/RunEventDetails.tsx
+++ b/src/components/RunEventDetails.tsx
@@ -1,4 +1,4 @@
-import { Clock, MessageSquare, Bot, Brain, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings } from 'lucide-react';
+import { Clock, MessageSquare, Bot, Brain, Wrench, FileText, Terminal, Users, ChevronDown, ChevronRight, Copy, User, Settings, Braces } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useToolOutputStreaming } from '@/hooks/useToolOutputStreaming';
 import { IconButton } from './IconButton';
@@ -190,6 +190,9 @@ const CONTEXT_PAGINATION_PAGE_SIZE = 20;
 export interface RunEventData extends Record<string, unknown> {
   messageSubtype?: MessageSubtype;
   content?: unknown;
+  spanName?: string;
+  scopeName?: string;
+  attributes?: Record<string, unknown>;
   toolSubtype?: ToolSubtype;
   toolName?: string;
   response?: string;
@@ -222,7 +225,7 @@ export interface RunEventData extends Record<string, unknown> {
   contextDeltaStatus?: ContextDeltaStatus;
 }
 
-export type EventType = 'message' | 'llm' | 'tool' | 'summarization';
+export type EventType = 'message' | 'llm' | 'tool' | 'summarization' | 'span';
 export type ToolSubtype = 'generic' | 'shell' | 'manage' | string;
 export type MessageSubtype = 'source' | 'intermediate' | 'result';
 export type OutputViewMode = 'text' | 'terminal' | 'markdown' | 'json' | 'yaml';
@@ -1336,6 +1339,69 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
     );
   };
 
+  // Spans with no semantic mapping are shown verbatim rather than dropped.
+  const renderSpanEvent = () => {
+    const spanName = event.data.spanName || 'Span';
+    const attributes = event.data.attributes ?? {};
+    const attributeEntries = Object.entries(attributes);
+
+    return (
+      <div className="space-y-6 h-full flex flex-col">
+        <div className="flex items-start flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-muted-foreground/10 flex items-center justify-center">
+              <Braces className="w-5 h-5 text-muted-foreground" />
+            </div>
+            <div>
+              <h3 className="text-foreground mb-1 font-mono" data-testid="run-event-details-heading">{spanName}</h3>
+              <div className="flex items-center gap-2 text-xs text-muted-foreground" data-testid="run-event-details-meta">
+                <Clock className="w-3 h-3" />
+                <span>{event.timestamp}</span>
+                {event.duration && (
+                  <>
+                    <span>•</span>
+                    <span>{event.duration}</span>
+                  </>
+                )}
+                {event.data.scopeName && (
+                  <>
+                    <span>•</span>
+                    <span className="font-mono">{event.data.scopeName}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex flex-col flex-1 min-h-0">
+          <div className="text-sm text-muted-foreground mb-2">Attributes</div>
+          {attributeEntries.length > 0 ? (
+            <div
+              className="rounded-[6px] border border-border overflow-auto flex-1"
+              data-testid="run-event-details-span-attributes"
+            >
+              <table className="w-full text-xs">
+                <tbody>
+                  {attributeEntries.map(([key, value]) => (
+                    <tr key={key} className="border-b border-border last:border-b-0 align-top">
+                      <td className="px-3 py-1.5 font-mono text-muted-foreground whitespace-nowrap">{key}</td>
+                      <td className="px-3 py-1.5 font-mono text-foreground break-all">
+                        {typeof value === 'string' ? value : JSON.stringify(value)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <div className="text-sm text-muted-foreground">No attributes</div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="bg-card h-full flex flex-col" data-testid="run-event-details">
       <div className="flex-1 overflow-y-auto p-6">
@@ -1343,6 +1409,7 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
         {event.type === 'llm' && renderLLMEvent()}
         {event.type === 'tool' && renderToolEvent()}
         {event.type === 'summarization' && renderSummarizationEvent()}
+        {event.type === 'span' && renderSpanEvent()}
       </div>
     </div>
   );

--- a/src/components/RunEventsList.tsx
+++ b/src/components/RunEventsList.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { MessageSquare, Bot, Wrench, FileText, Terminal, Users, Loader2 } from 'lucide-react';
+import { MessageSquare, Bot, Wrench, FileText, Terminal, Users, Loader2, Braces } from 'lucide-react';
 import { type EventType, type MessageSubtype, type RunEventData } from './RunEventDetails';
 import { StatusIndicator, type Status } from './StatusIndicator';
 
@@ -47,6 +47,8 @@ export function RunEventsList({
         return <Wrench className="w-4 h-4 text-[var(--agyn-cyan)]" />;
       case 'summarization':
         return <FileText className="w-4 h-4 text-muted-foreground" />;
+      case 'span':
+        return <Braces className="w-4 h-4 text-muted-foreground" />;
     }
   };
 
@@ -59,6 +61,7 @@ export function RunEventsList({
       case 'tool':
         return 'bg-[var(--agyn-cyan)]/10 border-[var(--agyn-cyan)]/20';
       case 'summarization':
+      case 'span':
         return 'bg-muted-foreground/10 border-muted-foreground/20';
     }
   };
@@ -85,6 +88,8 @@ export function RunEventsList({
         return event.data?.toolName || 'Tool Call';
       case 'summarization':
         return 'Summarization';
+      case 'span':
+        return event.data?.spanName || 'Span';
       default:
         return 'Event';
     }

--- a/src/components/screens/RunScreen.tsx
+++ b/src/components/screens/RunScreen.tsx
@@ -3,6 +3,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import {
   ArrowLeft,
   Bot,
+  Braces,
   Eye,
   EyeOff,
   FileText,
@@ -27,7 +28,7 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 
-export type EventFilter = 'message' | 'llm' | 'tool' | 'summary';
+export type EventFilter = 'message' | 'llm' | 'tool' | 'summary' | 'span';
 export type StatusFilter = 'running' | 'finished' | 'failed';
 
 interface RunScreenProps {
@@ -41,6 +42,7 @@ interface RunScreenProps {
     llm: number;
     tools: number;
     summaries: number;
+    spans: number;
   };
   tokens: {
     input: number;
@@ -531,6 +533,26 @@ export default function RunScreen({
                             </span>
                           </div>
                           {eventFilterSet.has('summary') ? (
+                            <Eye className="h-4 w-4 text-primary" />
+                          ) : (
+                            <EyeOff className="h-4 w-4 text-[var(--agyn-text-subtle)]" />
+                          )}
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
+                          className="flex items-center justify-between rounded-md px-3 py-2 text-sm transition-colors hover:bg-muted focus:bg-muted"
+                          onSelect={(event) => {
+                            event.preventDefault();
+                            handleToggleEventFilter('span');
+                          }}
+                        >
+                          <div className="flex items-center gap-2">
+                            <Braces className="h-4 w-4 text-muted-foreground" />
+                            <span>Span</span>
+                            <span className="text-xs text-[var(--agyn-text-subtle)]">
+                              ({formatNumber(statistics.spans)})
+                            </span>
+                          </div>
+                          {eventFilterSet.has('span') ? (
                             <Eye className="h-4 w-4 text-primary" />
                           ) : (
                             <EyeOff className="h-4 w-4 text-[var(--agyn-text-subtle)]" />

--- a/src/lib/eventMapping.ts
+++ b/src/lib/eventMapping.ts
@@ -232,6 +232,19 @@ export function createUiEvent(event: RunTimelineEvent, options?: CreateUiEventOp
         },
       };
     }
+    case 'span':
+      return {
+        id: event.id,
+        type: 'span',
+        timestamp,
+        duration,
+        status,
+        data: {
+          spanName: event.span?.name ?? '',
+          scopeName: event.span?.scopeName ?? undefined,
+          attributes: event.span?.attributes ?? {},
+        },
+      };
     default:
       return assertNever(event.type);
   }

--- a/src/pages/AgentsRunScreen.tsx
+++ b/src/pages/AgentsRunScreen.tsx
@@ -20,9 +20,9 @@ import { toContextRecord } from '@/lib/llmContext';
 import { buildToolLinkData } from '@/lib/toolDataParsing';
 import { formatDuration } from '@/components/agents/runTimelineFormatting';
 
-const EVENT_FILTER_OPTIONS: EventFilter[] = ['message', 'llm', 'tool', 'summary'];
+const EVENT_FILTER_OPTIONS: EventFilter[] = ['message', 'llm', 'tool', 'summary', 'span'];
 const STATUS_FILTER_OPTIONS: StatusFilter[] = ['running', 'finished', 'failed'];
-const API_EVENT_TYPES: RunEventType[] = ['invocation_message', 'injection', 'llm_call', 'tool_execution', 'summarization'];
+const API_EVENT_TYPES: RunEventType[] = ['invocation_message', 'injection', 'llm_call', 'tool_execution', 'summarization', 'span'];
 const API_EVENT_STATUSES: RunEventStatus[] = ['running', 'success', 'error'];
 const LLM_CONTEXT_PAGE_LIMIT = 100;
 
@@ -39,6 +39,7 @@ const EVENT_FILTER_TO_TYPES: Record<EventFilter, RunEventType[]> = {
   llm: ['llm_call'],
   tool: ['tool_execution'],
   summary: ['summarization'],
+  span: ['span'],
 };
 
 const STATUS_FILTER_TO_STATUSES: Record<StatusFilter, RunEventStatus[]> = {
@@ -528,6 +529,7 @@ export function AgentsRunScreen() {
         llm: 0,
         tools: 0,
         summaries: 0,
+        spans: 0,
       };
     }
     const counts = summary.countsByType ?? {};
@@ -537,6 +539,7 @@ export function AgentsRunScreen() {
       llm: counts.llm_call ?? 0,
       tools: counts.tool_execution ?? 0,
       summaries: counts.summarization ?? 0,
+      spans: counts.span ?? 0,
     };
   }, [filteredEventCount, runSummary]);
 

--- a/test/unit/runs.spec.ts
+++ b/test/unit/runs.spec.ts
@@ -31,6 +31,8 @@ vi.mock('@/api/client', () => ({
 
 const TRACE_ID = Uint8Array.from({ length: 16 }, (_, idx) => idx + 1);
 const MESSAGE_SPAN_ID = Uint8Array.from([0x43, 0xb1, 0x08, 0xa6, 0x15, 0x24, 0x47, 0x0b]);
+const LIFECYCLE_TRACE_ID = Uint8Array.from({ length: 16 }, () => 0xaa);
+const WORK_TRACE_ID = Uint8Array.from({ length: 16 }, () => 0xbb);
 
 const stringAttr = (key: string, value: string): KeyValue =>
   create(KeyValueSchema, {
@@ -62,6 +64,41 @@ function resourceSpansWithInvocationMessage(): ResourceSpans {
   });
 }
 
+// The lifecycle trace holds the newest span; the work trace holds the run.
+function resourceSpansAcrossTraces(): ResourceSpans {
+  const span = (traceId: Uint8Array, spanId: number, name: string, startUnixNano: bigint) =>
+    create(SpanSchema, {
+      traceId,
+      spanId: Uint8Array.from({ length: 8 }, () => spanId),
+      parentSpanId: new Uint8Array(8),
+      name,
+      kind: Span_SpanKind.INTERNAL,
+      startTimeUnixNano: startUnixNano,
+      endTimeUnixNano: startUnixNano + 1_000_000n,
+    });
+
+  return create(ResourceSpansSchema, {
+    resource: create(ResourceSchema, {
+      attributes: [stringAttr('agyn.thread.id', 'thread-123')],
+    }),
+    scopeSpans: [
+      create(ScopeSpansSchema, {
+        spans: [
+          span(LIFECYCLE_TRACE_ID, 0x01, 'op.dispatch.shutdown', 2_000_000_000_000_000_000n),
+          span(LIFECYCLE_TRACE_ID, 0x02, 'session_loop', 1_000_000_000_000_000_000n),
+          span(WORK_TRACE_ID, 0x03, 'run_turn', 1_500_000_000_000_000_000n),
+          span(WORK_TRACE_ID, 0x04, 'stream_request', 1_500_000_001_000_000_000n),
+          span(WORK_TRACE_ID, 0x05, 'handle_responses', 1_500_000_002_000_000_000n),
+        ],
+      }),
+    ],
+  });
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
 describe('runs.findRunByMessageId', () => {
   afterEach(() => {
     listSpansMock.mockReset();
@@ -79,16 +116,25 @@ describe('runs.findRunByMessageId', () => {
     expect(listSpansMock).toHaveBeenNthCalledWith(1, {
       organizationId: 'org-123',
       filter: { messageId: '43b108a61524470b' },
-      pageSize: 1,
+      pageSize: 500,
       pageToken: '',
       orderBy: 1,
     });
     expect(listSpansMock).toHaveBeenNthCalledWith(2, {
       organizationId: 'org-123',
-      filter: { names: ['invocation.message'] },
       pageSize: 500,
       pageToken: '',
       orderBy: 1,
     });
+  });
+
+  it('prefers the trace carrying the run over the session-lifecycle trace', async () => {
+    listSpansMock.mockResolvedValueOnce({
+      resourceSpans: [resourceSpansAcrossTraces()],
+    });
+
+    const run = await runs.findRunByMessageId('org-123', '43b108a61524470b');
+
+    expect(run).toEqual({ runId: bytesToHex(WORK_TRACE_ID) });
   });
 });

--- a/test/unit/spanToEvent.spec.ts
+++ b/test/unit/spanToEvent.spec.ts
@@ -219,8 +219,20 @@ describe('spanToEvent conversions', () => {
     expect(event.durationMs).toBeNull();
   });
 
-  it('throws on unknown span names', () => {
+  it('keeps unknown span names as raw span events', () => {
     const span = buildSpan({ name: 'unexpected.span' });
-    expect(() => spanToEvent(span, [threadAttr])).toThrow('Unhandled span name');
+    const event = spanToEvent(span, [threadAttr], 'codex-app-server');
+
+    expect(event.type).toBe('span');
+    expect(event.span?.name).toBe('unexpected.span');
+    expect(event.span?.scopeName).toBe('codex-app-server');
+  });
+
+  it('exposes span and resource attributes on raw span events', () => {
+    const span = buildSpan({ name: 'op.dispatch.shutdown', attributes: [stringAttr('agyn.tool.name', 'shell')] });
+    const event = spanToEvent(span, [threadAttr]);
+
+    expect(event.span?.attributes['agyn.tool.name']).toBe('shell');
+    expect(event.span?.resourceAttributes['agyn.thread.id']).toBe('thread-123');
   });
 });


### PR DESCRIPTION
The run view rendered four span names — `invocation.message`, `llm.call`, `tool.execution`, `summarization` — and threw away everything else: an unmapped name *raised*, so a real trace produced nothing at all. Nothing emits those four names, so the view has only ever been able to display spans that do not exist.

- **Unknown spans render as themselves**, with their attributes, instead of being dropped on the way in. The semantic types are unchanged — they become an adapter over the data rather than a gate on it.
- **`findRunByMessageId`** took the newest span a message touched and used its trace. The newest span is the session shutting down, whose trace holds two spans and none of the work; the turn sits in a trace the lookup never saw. It now scores the traces a message spans and takes the one carrying the run.
- **`listOrganizationRuns`** filtered on `invocation.message`, which no producer emits, so the list was permanently empty.

Verified against real data: for one message the lookup now resolves to the 40-span turn instead of a 2-span session trace.