### PR TITLE
Read the exec command under the key codex writes it

### DIFF
--- a/src/components/RunEventDetails.tsx
+++ b/src/components/RunEventDetails.tsx
@@ -996,7 +996,10 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
     };
 
     const input = parseInput();
-    const command = input?.command || event.data.command || '';
+    // Each CLI names the field its own way -- Claude Code's Bash tool sends
+    // `command`, codex's exec sends `cmd` -- and the span carries whatever the
+    // CLI recorded rather than a normalised copy.
+    const command = input?.command || input?.cmd || event.data.command || '';
     const cwd = input?.cwd || event.data.workingDir || '';
     const outputValue =
       outputViewMode === 'text' || outputViewMode === 'terminal'


### PR DESCRIPTION
A codex `exec_command` execution rendered an empty **Command** box while **Output** showed fine.

The span carries it correctly — `agyn.tool.input` holds `{"cmd": "mkdir -p /workspace && ..."}` — but the shell view reads `input?.command`. Claude Code's Bash tool writes `command`; codex's exec writes `cmd`. The span records whatever the CLI recorded rather than a normalised copy, so the reader accepts both.