### PR TITLE
Render every context role, not a list of known ones

### DIFF
--- a/src/components/RunEventDetails.tsx
+++ b/src/components/RunEventDetails.tsx
@@ -895,7 +895,11 @@ export function RunEventDetails({ event, runId, contextPagination, onLoadOlderCo
             )}
           </div>
           <div className="ml-5 space-y-3">
-            {(role === 'system' || role === 'user') && (
+            {/* Every role that is not rendered by a branch of its own: system,
+                user, and developer, which codex uses for the agent's own
+                instructions. Listing roles here meant a new one drew its header
+                and nothing under it. */}
+            {role !== 'tool' && role !== 'assistant' && (
               <div className="prose prose-sm max-w-none">
                 <MarkdownContent content={asString(message.content)} />
               </div>


### PR DESCRIPTION
A `developer` context item rendered its header and nothing under it.

The body was drawn only for roles named explicitly:

```jsx
{(role === 'system' || role === 'user') && <MarkdownContent .../>}
```

`tool` and `assistant` have branches of their own; anything else fell through with no body. Codex uses `developer` for the agent's own instructions, so the one item carrying an agent's system prompt was the one that could not be read.

Verified against the data rather than the screen: the item in that run carries **3,218 characters**, and no context item in the database has empty or missing text. The value was always there.

Inverted to `role !== 'tool' && role !== 'assistant'`, so a role nobody anticipated renders instead of disappearing.

Not a bug, for the record: `system` and `developer` appearing after the newer items is the new-vs-carried-over grouping working as intended — on a second call in a session, those were already sent and sort under the older group.

No component test: `RunEventDetails` needs substantial mocking to render, and `renderContextMessages` is a closure inside it rather than an exported unit. The existing 33 tests pass and typecheck is clean.