### PR TITLE
Sign out against providers with no end session endpoint

### DIFF
--- a/src/auth/sign-out.test.ts
+++ b/src/auth/sign-out.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getMetadata = vi.fn();
+const setSignedOutFlag = vi.fn();
+
+vi.mock('./user-manager', () => ({
+  userManager: { metadataService: { getMetadata } },
+}));
+vi.mock('./signed-out', () => ({ setSignedOutFlag }));
+
+const { signOut } = await import('./sign-out');
+
+function buildAuth() {
+  return { signoutRedirect: vi.fn().mockResolvedValue(undefined), removeUser: vi.fn().mockResolvedValue(undefined) };
+}
+
+describe('signOut', () => {
+  beforeEach(() => {
+    getMetadata.mockReset();
+    setSignedOutFlag.mockReset();
+  });
+
+  it('redirects to the provider when it publishes an end session endpoint', async () => {
+    getMetadata.mockResolvedValue({ end_session_endpoint: 'https://auth.agyn.dev:2496/logout' });
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(auth.signoutRedirect).toHaveBeenCalledOnce();
+    expect(auth.removeUser).not.toHaveBeenCalled();
+  });
+
+  // Dex publishes none and holds no browser session, so dropping the tokens is
+  // the whole sign-out. The flag is what renders the signed-out screen, since
+  // nothing navigates away to bring the app back through a fresh load.
+  it('signs out locally and raises the signed-out flag when the provider publishes none', async () => {
+    getMetadata.mockResolvedValue({ issuer: 'https://dex.agyn.dev:2496' });
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(setSignedOutFlag).toHaveBeenCalledOnce();
+    expect(auth.removeUser).toHaveBeenCalledOnce();
+    expect(auth.signoutRedirect).not.toHaveBeenCalled();
+  });
+
+  it('signs out locally when discovery cannot be read', async () => {
+    getMetadata.mockRejectedValue(new Error('network down'));
+    const auth = buildAuth();
+
+    await signOut(auth);
+
+    expect(auth.removeUser).toHaveBeenCalledOnce();
+    expect(auth.signoutRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/auth/sign-out.ts
+++ b/src/auth/sign-out.ts
@@ -1,0 +1,39 @@
+import { setSignedOutFlag } from './signed-out';
+import { userManager } from './user-manager';
+
+// Keycloak publishes end_session_endpoint and keeps a browser session that only
+// the redirect can end. Dex publishes neither, and signoutRedirect() throws on
+// the missing endpoint -- react-oidc-context catches that into auth.error, so a
+// sign-out that already succeeded renders a sign-in failure instead.
+//
+// Discovery being unreachable counts as absent: signing out locally is the safe
+// answer when the provider cannot be asked.
+async function supportsProviderSignOut(): Promise<boolean> {
+  if (!userManager) return false;
+  try {
+    const metadata = await userManager.metadataService.getMetadata();
+    return Boolean(metadata.end_session_endpoint);
+  } catch (error) {
+    console.warn('Could not read OIDC discovery; signing out locally.', error);
+    return false;
+  }
+}
+
+type SignOutAuth = {
+  signoutRedirect: () => Promise<void>;
+  removeUser: () => Promise<void>;
+};
+
+/**
+ * Signs out at the provider when it holds a session, and locally when it does
+ * not. The local path raises the signed-out flag itself, because nothing
+ * navigates away to bring the app back through a fresh load.
+ */
+export async function signOut(auth: SignOutAuth): Promise<void> {
+  if (await supportsProviderSignOut()) {
+    await auth.signoutRedirect();
+    return;
+  }
+  setSignedOutFlag();
+  await auth.removeUser();
+}

--- a/src/components/UserOrgMenu.tsx
+++ b/src/components/UserOrgMenu.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from './ui/dropdown-menu';
+import { signOut } from '@/auth/sign-out';
 import { cn } from '@/lib/utils';
 import { useTheme } from './theme-provider';
 import { useOrganization } from '@/organization/organization.runtime';
@@ -109,7 +110,7 @@ export function UserOrgMenu({ className }: { className?: string }) {
           </DropdownMenuSubContent>
         </DropdownMenuSub>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onSelect={() => void auth.signoutRedirect()} data-testid="sign-out">
+        <DropdownMenuItem onSelect={() => void signOut(auth)} data-testid="sign-out">
           <LogOut className="h-4 w-4 text-muted-foreground" />
           <span>Sign out</span>
         </DropdownMenuItem>


### PR DESCRIPTION
`signoutRedirect()` throws when discovery carries no `end_session_endpoint`, and react-oidc-context turns that into `auth.error` — which outranks the signed-out screen, so a sign-out that had already cleared the session rendered a sign-in failure.

Providers differ: Keycloak publishes the endpoint and holds a browser session only the redirect can end; Dex publishes neither. Ask discovery which one this is, and skip the redirect where there is no session to end.

Three tests cover the branches: endpoint present → redirect, absent → local sign-out, discovery unreachable → local sign-out.