### PR TITLE
Take sibling product addresses from configuration

### DIFF
--- a/charts/tracing-app/values.yaml
+++ b/charts/tracing-app/values.yaml
@@ -83,6 +83,9 @@ env:
     value: "{{ .Values.oidcResource }}"
   - name: API_BASE_URL
     value: "{{ .Values.apiBaseUrl }}"
+# CHAT_URL, TRACING_URL, CONSOLE_URL and SANDBOXES_URL are deliberately absent:
+# an explicit empty env var shadows extraEnvVarsCM, which is how the umbrella
+# feeds them. Set them here via extraEnvVars for a standalone install.
 envFrom: []
 extraEnvVars: []
 extraEnvVarsCM: ""

--- a/docker/40-generate-env.sh
+++ b/docker/40-generate-env.sh
@@ -8,6 +8,10 @@ escape_js() {
 }
 
 api_base_url=$(escape_js "${API_BASE_URL:-}")
+chat_url=$(escape_js "${CHAT_URL:-}")
+tracing_url=$(escape_js "${TRACING_URL:-}")
+console_url=$(escape_js "${CONSOLE_URL:-}")
+sandboxes_url=$(escape_js "${SANDBOXES_URL:-}")
 oidc_authority=$(escape_js "${OIDC_AUTHORITY:-}")
 oidc_client_id=$(escape_js "${OIDC_CLIENT_ID:-}")
 oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
@@ -15,6 +19,10 @@ oidc_scope=$(escape_js "${OIDC_SCOPE:-}")
 cat > "$CONFIG_PATH" <<EOF
 window.__ENV__ = {
   API_BASE_URL: "${api_base_url}",
+  CHAT_URL: "${chat_url}",
+  TRACING_URL: "${tracing_url}",
+  CONSOLE_URL: "${console_url}",
+  SANDBOXES_URL: "${sandboxes_url}",
   OIDC_AUTHORITY: "${oidc_authority}",
   OIDC_CLIENT_ID: "${oidc_client_id}",
   OIDC_SCOPE: "${oidc_scope}",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,9 @@
 type RuntimeEnv = {
   API_BASE_URL?: string;
+  CHAT_URL?: string;
+  TRACING_URL?: string;
+  CONSOLE_URL?: string;
+  SANDBOXES_URL?: string;
   OIDC_AUTHORITY?: string;
   OIDC_CLIENT_ID?: string;
   OIDC_SCOPE?: string;
@@ -53,8 +57,23 @@ export const oidcConfig: OidcConfig = {
   resource,
 };
 
+// Sibling product origins, keyed by product id. Set by the operator when the
+// apps are not served at <product>.<domain>; null falls back to derivation.
+const productUrls: Record<string, string | null> = {
+  chat: readProductUrl('CHAT_URL', 'VITE_CHAT_URL'),
+  tracing: readProductUrl('TRACING_URL', 'VITE_TRACING_URL'),
+  console: readProductUrl('CONSOLE_URL', 'VITE_CONSOLE_URL'),
+  sandboxes: readProductUrl('SANDBOXES_URL', 'VITE_SANDBOXES_URL'),
+};
+
+function readProductUrl(runtimeKey: keyof RuntimeEnv, envKey: keyof ImportMetaEnv): string | null {
+  const value = readConfigValue(runtimeKey, envKey);
+  return value ? stripTrailingSlash(value) : null;
+}
+
 export const config = {
   apiBaseUrl,
+  productUrls,
 };
 
 /**

--- a/src/lib/products.ts
+++ b/src/lib/products.ts
@@ -1,5 +1,5 @@
 import { Box, MessageCircle, SlidersVertical, TrendingUp, type LucideIcon } from 'lucide-react';
-import { deriveSiblingUrl } from '@/config';
+import { config, deriveSiblingUrl } from '@/config';
 
 export type Product = {
   id: string;
@@ -23,5 +23,6 @@ export const PRODUCTS: Product[] = [
 /** Null when the product is unreleased or the host has no derivable sibling. */
 export function productUrl(product: Product): string | null {
   if (product.comingSoon) return null;
-  return deriveSiblingUrl(product.subdomain);
+  // Derivation only holds when every app sits at <product>.<domain>.
+  return config.productUrls[product.id] ?? deriveSiblingUrl(product.subdomain);
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,10 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string;
+  readonly VITE_CHAT_URL?: string;
+  readonly VITE_TRACING_URL?: string;
+  readonly VITE_CONSOLE_URL?: string;
+  readonly VITE_SANDBOXES_URL?: string;
   readonly VITE_OIDC_AUTHORITY?: string;
   readonly VITE_OIDC_CLIENT_ID?: string;
   readonly VITE_OIDC_SCOPE?: string;
@@ -15,6 +19,10 @@ interface ImportMeta {
 interface Window {
   __ENV__?: {
     API_BASE_URL?: string;
+    CHAT_URL?: string;
+    TRACING_URL?: string;
+    CONSOLE_URL?: string;
+    SANDBOXES_URL?: string;
     OIDC_AUTHORITY?: string;
     OIDC_CLIENT_ID?: string;
     OIDC_SCOPE?: string;


### PR DESCRIPTION
The product switcher built its links by replacing the first label of the current hostname with the sibling's name, which holds only while every app is served at `<product>.<domain>`. An install at `tracing-agyn.example` derived `chat.example` — a host that exists nowhere on it — so every entry led to a 404.

The image offered no way to correct it: `env.js` carried `API_BASE_URL` and the OIDC settings and nothing else.

Now reads `CHAT_URL`, `TRACING_URL`, `CONSOLE_URL` and `SANDBOXES_URL`, deriving only where one is unset, so default installs and devspace are untouched. The umbrella feeds them through `envFrom` from a ConfigMap it derives from the routes it already declares, which is why the keys are deliberately absent from the chart's `env:` block — an explicit empty variable would shadow the ConfigMap and put the guessing back.

Same change as agynio/console-app#143, which carries the tests for the shared logic.