### PR TITLE
Provision E2E on the platform VM

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -1,7 +1,7 @@
 version: v2beta1
 
 vars:
-  APP_NAMESPACE: platform
+  APP_NAMESPACE: agyn-platform
   # Carries Node and already ships in the VM's image store, so this pulls
   # nothing. Keep in sync with the image in patch_deployment below.
   DEV_IMAGE: ghcr.io/agynio/devcontainer-agyn:sha-f739923


### PR DESCRIPTION
`run-tests` moved to the VM's contract and reads `AGYN_API_TOKEN` from the environment. The bootstrap action never exported it — it left Terraform state behind instead — so every run since has died before a single test ran:

```
AGYN_API_TOKEN is not set; run a provisioning action before this one.
```

DevSpace follows the install to `agyn-platform`, which it moved to on 2026-08-09. `platform` is empty, so the patch and sync looked for a deployment that was no longer there — the same fix console-app made in agynio/console-app#140.

Depends on agynio/e2e#255, which boots an image the upgrade can actually reach.