### PR TITLE
Renew from the provider's session, for installs that can

### DIFF
--- a/charts/tracing-app/values.yaml
+++ b/charts/tracing-app/values.yaml
@@ -200,6 +200,22 @@ metrics:
 
 oidcAuthority: ""
 oidcClientId: ""
+# offline_access stays in the default: a refresh token is the only renewal that
+# works against an arbitrary provider. The alternative -- renewing from the
+# provider's session through a hidden frame -- needs that frame to be first-party
+# to the issuer, and browsers block it wherever the app and the issuer are not
+# the same site. Nothing in discovery says which case an install is in.
+#
+# An install whose issuer is a sibling hostname should drop offline_access and
+# hold no refresh token at all; the umbrella does exactly that for the bundled
+# provider. Dex rotates refresh tokens either way, which is what RFC 9700 asks
+# of a public client that keeps one.
+#
+# Dropping it against a provider this chart does not configure takes one more
+# step there: <origin>/silent-renew has to be registered as a redirect URI, the
+# same way the callback is. The app cannot do that or detect that it is missing
+# -- the provider answers the renewal with an error the frame swallows, and
+# sessions end at token expiry instead.
 oidcScope: "openid profile email offline_access"
 oidcResource: ""
 apiBaseUrl: /api

--- a/src/auth/AuthGate.tsx
+++ b/src/auth/AuthGate.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/Button';
 import { oidcConfig } from '@/config';
 import { clearSignedOutFlag, readSignedOutFlag } from './signed-out';
 import { getSigninRedirectArgs } from './return-to';
+import { SilentRenewScreen } from './SilentRenewScreen';
 import { userManager } from './user-manager';
 
 type AuthGateProps = {
@@ -143,9 +144,18 @@ function AuthErrorBoundary({ children }: { children: ReactNode }) {
   return <>{children}</>;
 }
 
+export const silentRenewPath = '/silent-renew';
+
 export function AuthGate({ children }: AuthGateProps) {
   if (!oidcConfig.enabled) return <>{children}</>;
   if (!userManager) throw new Error('auth: user manager not initialized');
+
+  // The route below this gate never rendered for a renewal frame: the gate runs
+  // first and would sign in again inside the frame. Checked on the raw location
+  // because this has to win before AuthProvider mounts.
+  if (window.location.pathname === silentRenewPath) {
+    return <SilentRenewScreen />;
+  }
 
   return (
     <AuthProvider userManager={userManager} onSigninCallback={handleSigninCallback}>


### PR DESCRIPTION
Wires renewal through a hidden frame against the provider's session, so an install can drop `offline_access` and hold no refresh token at all.

Inert unless it is dropped: with `offline_access` present oidc-client-ts renews from the refresh token and never opens the frame, so `silent_redirect_uri` goes unread and the gate never sees the path. The chart default still asks for it, so nothing changes for an install that keeps it.

The gate answers `/silent-renew` before `AuthProvider` mounts — from a route it would sit below the gate and the frame would run the whole sign-in flow in its own context.

Dropping `offline_access` against a provider this chart does not configure also needs `<origin>/silent-renew` registered there as a redirect URI; the app cannot detect that it is missing. The values file says so.